### PR TITLE
chore(legal): add developer program agreement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
-
+## [3.1.1] - 2023-06-07
+### Added
+- Developer program agreement note to README
 ## [3.1.0] - 2023-02-14
 ### Added
 - Support for deactivate user endpoint

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ smartsheet.sheets.listSheets(options)
 ## Advanced Topics
 For details about more advanced features, see [Advanced Topics](ADVANCED.md).
 
+## Developer Agreement
+Review the [Developer Program Agreement](https://www.smartsheet.com/legal/developer-program-agreement).
+
 ## Acknowledgements
 
 We would like to thank the following people for their contributions to this project:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Smartsheet JavaScript client SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Developers from outside the Smartsheet organisation must agree to the conditions of the developer program. Added link to developer agreement to README and bumped package version to reflect on NPM.