### PR TITLE
remove request in favor of axios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+## [3.2.0] - 2023-08-17
+### Security
+- Removed `request` dependency and replaced it with `Axios`
+
 ## [3.1.2] - 2023-06-13
 ### Fixed
 - Added missing euBaseURI constant for smartsheet.eu 

--- a/lib/utils/httpRequestor.js
+++ b/lib/utils/httpRequestor.js
@@ -11,7 +11,7 @@ exports.create = function(requestorConfig) {
     : requestLogger.empty;
 
   var request = requestorConfig.request ||
-                Promise.promisifyAll(require("request"), {multiArgs: true});
+                Promise.promisifyAll(require("axios"), {multiArgs: true});
 
   var handleResponse = requestorConfig.handleResponse ||
                        require('./responseHandler');
@@ -83,12 +83,12 @@ exports.create = function(requestorConfig) {
   };
 
   var get = (options, callback) =>
-    methodRequest(options, request.getAsync, 'GET', callback);
+    methodRequest(options, request.get, 'GET', callback);
 
   var post = (options, callback) => {
     var requestExtension = { body: JSON.stringify(options.body) };
 
-    return methodRequest(options, request.postAsync, 'POST', callback, requestExtension);
+    return methodRequest(options, request.post, 'POST', callback, requestExtension);
   };
 
   var getFileBody = (options) => {
@@ -102,56 +102,67 @@ exports.create = function(requestorConfig) {
   var postFile = (options, callback) => {
     var requestExtension = { body: getFileBody(options) };
 
-    return methodRequest(options, request.postAsync, 'POST', callback, requestExtension);
+    return methodRequest(options, request.post, 'POST', callback, requestExtension);
   };
 
   var deleteFunc = (options, callback)  =>
-    methodRequest(options, request.delAsync, 'DELETE', callback);
+    methodRequest(options, request.delete, 'DELETE', callback);
 
   var put = (options, callback) => {
     var requestExtension = { body: JSON.stringify(options.body) };
 
-    return methodRequest(options, request.putAsync, 'PUT', callback, requestExtension);
+    return methodRequest(options, request.put, 'PUT', callback, requestExtension);
   };
 
   var methodRequest = (options, method, methodName, callback, requestExtension) => {
     var baseRequestOptions = {
       url: buildUrl(options),
       headers: buildHeaders(options),
-      qs: options.queryParameters,
-      encoding: options.encoding,
-      gzip: true
+      params: options.queryParameters,
+      responseEncoding: options.encoding
     };
+    var url = buildUrl(options);
     var requestOptions = _.extend(baseRequestOptions, requestExtension);
 
     var retryOptions = _.pick(options, 'maxRetryDurationMillis', 'calcRetryBackoff');
 
     logger.logRequest(methodName, requestOptions);
 
-    return makeRequestWithRetries(method, methodName, requestOptions, retryOptions, callback);
+    return makeRequestWithRetries(url, method, methodName, requestOptions, retryOptions, callback);
   };
 
-  var makeRequestWithRetries = (method, methodName, requestOptions, retryOptions, callback) => {
+  var makeRequestWithRetries = (url, method, methodName, requestOptions, retryOptions, callback) => {
     var effectiveRetryOptions = _.defaults(retryOptions, defaultRetryOptions);
 
     effectiveRetryOptions.endRetryTime = Date.now() + effectiveRetryOptions.maxRetryDurationMillis;
 
-    return retryHelper(method, methodName, requestOptions, effectiveRetryOptions, 0)
-      .tap(logger.logSuccessfulResponse)
-      .tapCatch(error => logger.logErrorResponse(methodName, requestOptions, error))
-      .get('content')
-      .catch(error => Promise.reject(_.omit(error, 'headers', 'body')))
-      .nodeify(callback);
+    return retryHelper(url, method, methodName, requestOptions, effectiveRetryOptions, 0)
+      .then((response) => {
+        logger.logSuccessfulResponse(response);
+
+        if (callback) {
+          callback(undefined, response.content);
+        }
+        
+        return response.content;
+      })
+      .catch((error) => {
+        logger.logErrorResponse(methodName, requestOptions, error);
+
+        if (callback) {
+          callback(error, undefined);
+        }
+        
+        return new Promise.reject(_.omit(error, 'headers', 'body'));
+      });
   };
 
-  var retryHelper = (method, methodName, requestOptions, retryOptions, numRetries) =>
-    makeRequest(method, methodName, requestOptions)
-      .catch(retryWithBackoffHelper(method, methodName, requestOptions, retryOptions, numRetries));
+  var retryHelper = (url, method, methodName, requestOptions, retryOptions, numRetries) =>
+    method(url, requestOptions)
+      .then(handleResponse)
+      .catch(retryWithBackoffHelper(url, method, methodName, requestOptions, retryOptions, numRetries));
 
-  var makeRequest = (method, methodName, requestOptions) =>
-    method(requestOptions).spread(handleResponse);
-
-  var retryWithBackoffHelper = (method, methodName, requestOptions, retryOptions, numRetries) => {
+  var retryWithBackoffHelper = (url, method, methodName, requestOptions, retryOptions, numRetries) => {
     return error => {
       var backoffMillis = retryOptions.calcRetryBackoff(numRetries, error);
 
@@ -168,7 +179,7 @@ exports.create = function(requestorConfig) {
       var nextRetry = numRetries + 1;
       logger.logRetryAttempt(methodName, requestOptions, error, nextRetry);
       return Promise.delay(backoffMillis)
-        .then(() => retryHelper(method, methodName, requestOptions, retryOptions, nextRetry));
+        .then(() => retryHelper(url, method, methodName, requestOptions, retryOptions, nextRetry));
     };
   };
 

--- a/lib/utils/responseHandler.js
+++ b/lib/utils/responseHandler.js
@@ -1,33 +1,30 @@
 var Promise = require("bluebird");
 
-module.exports = (response, body) => {
+module.exports = (response) => {
   var outResponse = {
-    statusCode: response.statusCode,
+    statusCode: response.status,
     headers: response.headers,
-    body: body
+    body: response.data
   };
 
-  if (response.statusCode != 200) {
+  if (response.status != 200) {
     var errorResponse = outResponse;
     if (/\bapplication\/json\b/.test(response.headers['content-type'])) {
-      var responseBody = JSON.parse(body);
-      errorResponse.errorCode = responseBody.errorCode;
-      errorResponse.message = responseBody.message;
-      errorResponse.refId = responseBody.refId;
+      errorResponse.errorCode = response.data.errorCode;
+      errorResponse.message = response.data.message;
+      errorResponse.refId = response.data.refId;
       
-      if (responseBody.detail !== undefined) {
-        errorResponse.detail = responseBody.detail;
+      if (response.data.detail !== undefined) {
+        errorResponse.detail = response.data.detail;
       }
     } else {
-      errorResponse.message = body;
+      errorResponse.message = response.data;
     }
 
     return new Promise.reject(errorResponse);
-  } else if (response.headers['content-type'] === 'application/json;charset=UTF-8') {
-    outResponse.content = JSON.parse(body);
-    return outResponse;
-  } else {
-    outResponse.content = body;
-    return outResponse;
   }
+
+  outResponse.content = response.data;
+
+  return outResponse;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "3.1.0",
+  "version": "3.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -535,6 +535,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -765,6 +766,7 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -772,7 +774,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -829,12 +832,36 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "dev": true
     },
     "aws4": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+      "dev": true
+    },
+    "axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "bach": {
       "version": "1.2.0",
@@ -918,6 +945,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -1072,7 +1100,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true
     },
     "chalk": {
       "version": "4.1.2",
@@ -1327,7 +1356,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true
     },
     "coveralls": {
       "version": "3.1.1",
@@ -1389,6 +1419,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1603,6 +1634,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -1890,7 +1922,8 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "dev": true
     },
     "eyes": {
       "version": "0.1.8",
@@ -1912,12 +1945,14 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "1.1.4",
@@ -2023,6 +2058,11 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2051,12 +2091,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -2156,6 +2198,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -2735,12 +2778,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -2897,6 +2942,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -3149,7 +3195,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true
     },
     "is-unc-path": {
       "version": "1.0.0",
@@ -3349,7 +3396,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "dev": true
     },
     "jsesc": {
       "version": "2.5.2",
@@ -3448,12 +3496,14 @@
     "json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -3464,7 +3514,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
     },
     "json5": {
       "version": "2.2.3",
@@ -3476,6 +3527,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -4497,7 +4549,8 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -4796,7 +4849,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true
     },
     "picocolors": {
       "version": "1.0.0",
@@ -4973,10 +5027,16 @@
         "fromentries": "^1.2.0"
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "dev": true
     },
     "pump": {
       "version": "2.0.1",
@@ -5002,12 +5062,14 @@
     "punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true
     },
     "qs": {
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -5182,6 +5244,7 @@
       "version": "2.88.2",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -5277,7 +5340,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -5291,7 +5355,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "semver": {
       "version": "5.7.1",
@@ -5666,6 +5731,7 @@
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
       "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -5922,6 +5988,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -5931,6 +5998,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -5938,7 +6006,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true
     },
     "type": {
       "version": "1.2.0",
@@ -6090,6 +6159,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -6115,7 +6185,8 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
     },
     "v8flags": {
       "version": "3.2.0",
@@ -6146,6 +6217,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Smartsheet JavaScript client SDK",
   "main": "index.js",
   "scripts": {
@@ -30,9 +30,9 @@
   },
   "homepage": "http://developers.smartsheet.com",
   "dependencies": {
+    "axios": "^1.4.0",
     "bluebird": "^3.5.0",
     "extend": "^3.0.2",
-    "request": "^2.88.0",
     "underscore": "^1.8.2",
     "winston": "^2.3.1"
   },

--- a/test/functional/responseHandler_test.js
+++ b/test/functional/responseHandler_test.js
@@ -11,15 +11,21 @@ describe('Utils Unit Tests', function() {
       var mockBody = null;
 
       beforeEach(() => {
+        mockBody = {
+          hello: "world"
+        };
+        mockBodyError = {
+          errorCode: 911,
+          message: "EMERGENCY"
+        };
+        
         mockResponse = {
-          statusCode: 200,
+          status: 200,
           headers: {
             'content-type':'application/json;charset=UTF-8'
-          }
+          },
+          data: mockBody
         };
-
-        mockBody = '{"hello":"world"}';
-        mockBodyError = '{"errorCode": 911, "message":"EMERGENCY"}';
       });
 
       afterEach(() => {
@@ -28,24 +34,27 @@ describe('Utils Unit Tests', function() {
       });
 
       it('should return a rejected promise if status code is not 200', () => {
-        mockResponse.statusCode = 500;
-        handleResponse(mockResponse, mockBodyError)
+        mockResponse.status = 500;
+        mockResponse.data = mockBodyError;
+        handleResponse(mockResponse)
           .catch(function(error) {
-            error.statusCode.should.equal(500);
+            error.status.should.equal(500);
             error.message.should.equal('EMERGENCY');
             error.errorCode.should.equal(911);
           });
       });
 
       it('should return parsed JSON body', () => {
-        var parsed = JSON.parse(mockBody);
-        var result = handleResponse(mockResponse, mockBody);
-        result.content.hello.should.equal(parsed.hello);
+        var result = handleResponse(mockResponse);
+        result.content.hello.should.equal(mockBody.hello);
       });
 
       it('should return the body if content type is not application/json', () => {
         mockResponse.headers['content-type'] = 'application/xml';
-        var result = handleResponse(mockResponse, mockBody);
+        mockResponse.data = mockBody;
+        var result = handleResponse(mockResponse);
+        result.headers.should.equal(mockResponse.headers);
+        result.statusCode.should.equal(mockResponse.status);
         result.content.should.equal(mockBody);
       });
     });

--- a/test/functional/utils/responseHandler_test.js
+++ b/test/functional/utils/responseHandler_test.js
@@ -4,56 +4,45 @@ const responseHandler = require('../../../lib/utils/responseHandler');
 describe('responseHandler', () => {
   describe('with successful response', () => {
     it('should return the parsed body when content-type is JSON and charset is UTF-8', () => {
+      const body = { id: 1, name: 'John Doe' };
       const response = {
-        statusCode: 200,
-        headers: { 'content-type': 'application/json;charset=UTF-8' }
+        status: 200,
+        headers: { 'content-type': 'application/json;charset=UTF-8' },
+        data: body
       };
-      const body = JSON.stringify({ id: 1, name: 'John Doe' });
 
-      const result = responseHandler(response, body);
+      const result = responseHandler(response);
 
-      result.should.have.properties(['statusCode', 'headers', 'content']);
-      result.statusCode.should.equal(response.statusCode);
-      result.headers.should.equal(response.headers);
-      result.content.should.deepEqual(JSON.parse(body));
-    });
-
-    it('should return the raw body when content-type is not JSON', () => {
-      const response = {
-        statusCode: 200,
-        headers: { 'content-type': 'text/plain' }
-      };
-      const body = 'This is a test';
-
-      const result = responseHandler(response, body);
-
-      result.should.have.properties(['statusCode', 'headers', 'content']);
-      result.statusCode.should.equal(response.statusCode);
-      result.headers.should.equal(response.headers);
-      result.content.should.equal(body);
+      result.should.deepEqual({
+        statusCode: response.status,
+        headers: response.headers,
+        content: response.data,
+        body: response.data
+      });
     });
   });
 
   describe('with failed response', () => {
     it('should return a rejected promise with an error object', () => {
-      const response = {
-        statusCode: 500,
-        headers: { 'content-type': 'application/json' }
-      };
       const body = {
         errorCode: 'SOME_ERROR_CODE',
         message: 'Some error message',
         refId: 'SOME_REF_ID',
         detail: 'Some error detail'
       };
+      const response = {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+        data: body
+      };
 
-      return responseHandler(response, JSON.stringify(body))
+      return responseHandler(response)
         .then(() => {
           should.fail('Function should have thrown an error');
         })
         .catch((error) => {
           error.should.have.properties(['statusCode', 'headers', 'errorCode', 'message', 'refId', 'detail']);
-          error.statusCode.should.equal(response.statusCode);
+          error.statusCode.should.equal(response.status);
           error.headers.should.equal(response.headers);
           error.errorCode.should.equal(body.errorCode);
           error.message.should.equal(body.message);
@@ -63,19 +52,20 @@ describe('responseHandler', () => {
     });
 
     it('should return a rejected promise with an error message for non-JSON response', () => {
-      const response = {
-        statusCode: 500,
-        headers: { 'content-type': 'text/plain' }
-      };
       const body = 'Internal server error';
+      const response = {
+        status: 500,
+        headers: { 'content-type': 'text/plain' },
+        data: body
+      };
 
-      return responseHandler(response, body)
+      return responseHandler(response)
         .then(() => {
           should.fail('Function should have thrown an error');
         })
         .catch(error => {
           error.should.have.properties(['statusCode', 'headers', 'message']);
-          error.statusCode.should.equal(response.statusCode);
+          error.statusCode.should.equal(response.status);
           error.headers.should.equal(response.headers);
           error.message.should.equal(body);
         });

--- a/test/functional/utils_test.js
+++ b/test/functional/utils_test.js
@@ -1,12 +1,12 @@
-var request = require('request');
 var sinon = require('sinon');
 var Promise = require('bluebird');
 var _ = require('underscore');
 var packageJson = require('../../package.json');
 var fs = require('fs');
 const { smartSheetURIs } = require('../..');
+var axios = require('axios');
 
-var requestor = require('../../lib/utils/httpRequestor').create({request: request});
+var requestor = require('../../lib/utils/httpRequestor').create({request: axios});
 
 var sample = {
   name : 'name'
@@ -198,18 +198,20 @@ describe('Utils Unit Tests', function() {
     describe('#Successful request', function() {
       var requestStub = null;
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: request, handleResponse: () => ({content: true})});
+        .create({request: axios, handleResponse: () => ({ content: true })});
 
       beforeEach(() => {
-        requestStub = sinon.stub(request, 'getAsync');
+        requestStub = sinon.stub(axios, 'get');
         var mockResponse = {
-          statusCode: 200,
+          status: 200,
           headers: {
             'content-type':'application/json;charset=UTF-8'
+          },
+          data: {
+            hello: "world"
           }
         };
-        var mockBody = '{"hello":"world"}';
-        requestStub.returns(Promise.resolve([mockResponse, mockBody]));
+        requestStub.returns(Promise.resolve(mockResponse));
       });
 
       afterEach(() => {
@@ -231,11 +233,11 @@ describe('Utils Unit Tests', function() {
     describe('#Error on request', function() {
       var requestStub = null;
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: request, handleResponse: () => ({content: true})});
+        .create({request: axios, handleResponse: () => ({ content: true })});
       var mockBody;
 
       beforeEach(() => {
-        requestStub = sinon.stub(request, 'getAsync');
+        requestStub = sinon.stub(axios, 'get');
         var mockResponse = {
           statusCode: 403,
           headers: {
@@ -269,7 +271,7 @@ describe('Utils Unit Tests', function() {
       var spyGet;
 
       beforeEach(() => {
-        spyGet = sinon.spy(request, 'getAsync');
+        spyGet = sinon.spy(axios, 'get');
       });
 
       afterEach(() => {
@@ -284,20 +286,20 @@ describe('Utils Unit Tests', function() {
           'User-Agent': `smartsheet-javascript-sdk/${EXPECTED_VERSION}`
         };
         requestor.get(sampleRequest);
-        spyGet.args[0][0].headers.Authorization.should.equal(sampleHeaders.Authorization);
-        spyGet.args[0][0].headers.Accept.should.equal(sampleHeaders.Accept);
-        spyGet.args[0][0].headers['Content-Type'].should.equal(sampleHeaders['Content-Type']);
-        spyGet.args[0][0].headers['User-Agent'].should.equal(sampleHeaders['User-Agent']);
+        spyGet.args[0][1].headers.Authorization.should.equal(sampleHeaders.Authorization);
+        spyGet.args[0][1].headers.Accept.should.equal(sampleHeaders.Accept);
+        spyGet.args[0][1].headers['Content-Type'].should.equal(sampleHeaders['Content-Type']);
+        spyGet.args[0][1].headers['User-Agent'].should.equal(sampleHeaders['User-Agent']);
       });
 
       it('url sent to request should match given', () => {
         requestor.get(sampleRequest);
-        spyGet.args[0][0].url.should.equal('https://api.smartsheet.com/2.0/URL');
+        spyGet.args[0][0].should.equal('https://api.smartsheet.com/2.0/URL');
       });
 
       it('queryString sent to request should match given', () => {
         requestor.get(sampleRequestWithQueryParameters);
-        spyGet.args[0][0].qs.should.equal(sampleRequestWithQueryParameters.queryParameters);
+        spyGet.args[0][1].params.should.equal(sampleRequestWithQueryParameters.queryParameters);
       });
     });
 
@@ -305,7 +307,7 @@ describe('Utils Unit Tests', function() {
       var requestStub = null;
       var handleResponseStub = sinon.stub();
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: request, handleResponse: handleResponseStub});
+        .create({request: axios, handleResponse: handleResponseStub});
       var sampleRequestForRetry = null;
 
       function givenGetReturnsError() {
@@ -330,7 +332,7 @@ describe('Utils Unit Tests', function() {
       }
 
       beforeEach(() => {
-        requestStub = sinon.stub(request, 'getAsync');
+        requestStub = sinon.stub(axios, 'get');
         sampleRequestForRetry = _.extend({}, sampleRequest);
         sampleRequestForRetry.maxRetryDurationMillis = 30;
         sampleRequestForRetry.calcRetryBackoff = function (numRetry) {return Math.pow(3, numRetry);};
@@ -377,10 +379,10 @@ describe('Utils Unit Tests', function() {
       var requestStub = null;
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: request, handleResponse: () => ({content: true})});
+        .create({request: axios, handleResponse: () => ({content: true})});
 
       beforeEach(() => {
-        requestStub = sinon.stub(request, 'postAsync');
+        requestStub = sinon.stub(axios, 'post');
         var mockResponse = {
           statusCode: 200,
           headers: {
@@ -413,10 +415,10 @@ describe('Utils Unit Tests', function() {
       var mockBody = {error:true};
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: request, handleResponse: () => ({content: true})});
+        .create({request: axios, handleResponse: () => ({content: true})});
 
       beforeEach(() => {
-        requestStub = sinon.stub(request, 'postAsync');
+        requestStub = sinon.stub(axios, 'post');
         requestStub.returns(Promise.reject(mockBody));
       });
 
@@ -443,7 +445,7 @@ describe('Utils Unit Tests', function() {
       var spyPost;
 
       beforeEach(() => {
-        spyPost = sinon.spy(request, 'postAsync');
+        spyPost = sinon.spy(axios, 'post');
       });
 
       afterEach(() => {
@@ -458,25 +460,25 @@ describe('Utils Unit Tests', function() {
           'User-Agent': `smartsheet-javascript-sdk/${EXPECTED_VERSION}`
         };
         requestor.post(sampleRequest);
-        spyPost.args[0][0].headers.Authorization.should.equal(sampleHeaders.Authorization);
-        spyPost.args[0][0].headers.Accept.should.equal(sampleHeaders.Accept);
-        spyPost.args[0][0].headers['Content-Type'].should.equal(sampleHeaders['Content-Type']);
-        spyPost.args[0][0].headers['User-Agent'].should.equal(sampleHeaders['User-Agent']);
+        spyPost.args[0][1].headers.Authorization.should.equal(sampleHeaders.Authorization);
+        spyPost.args[0][1].headers.Accept.should.equal(sampleHeaders.Accept);
+        spyPost.args[0][1].headers['Content-Type'].should.equal(sampleHeaders['Content-Type']);
+        spyPost.args[0][1].headers['User-Agent'].should.equal(sampleHeaders['User-Agent']);
       });
 
       it('url sent to request should match given', () => {
         requestor.post(sampleRequest);
-        spyPost.args[0][0].url.should.equal('https://api.smartsheet.com/2.0/URL');
+        spyPost.args[0][0].should.equal('https://api.smartsheet.com/2.0/URL');
       });
 
       it('queryString sent to request should match given', () => {
         requestor.post(sampleRequestWithQueryParameters);
-        spyPost.args[0][0].qs.should.equal(sampleRequestWithQueryParameters.queryParameters);
+        spyPost.args[0][1].params.should.equal(sampleRequestWithQueryParameters.queryParameters);
       });
 
       it('body sent to request should match given', () => {
         requestor.post(sampleRequestWithQueryParameters);
-        spyPost.args[0][0].body.should.equal(JSON.stringify(sampleRequestWithQueryParameters.body));
+        spyPost.args[0][1].body.should.equal(JSON.stringify(sampleRequestWithQueryParameters.body));
       });
     });
 
@@ -485,7 +487,7 @@ describe('Utils Unit Tests', function() {
       var handleResponseStub = sinon.stub();
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: request, handleResponse: handleResponseStub});
+        .create({request: axios, handleResponse: handleResponseStub});
 
       var sampleRequestForRetry;
 
@@ -511,7 +513,7 @@ describe('Utils Unit Tests', function() {
       }
 
       beforeEach(() => {
-        requestStub = sinon.stub(request, 'postAsync');
+        requestStub = sinon.stub(axios, 'post');
 
         sampleRequestForRetry = _.extend({}, sampleRequest);
         sampleRequestForRetry.maxRetryDurationMillis = 30;
@@ -559,10 +561,10 @@ describe('Utils Unit Tests', function() {
       var requestStub = null;
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: request, handleResponse: () => ({content: true})});
+        .create({request: axios, handleResponse: () => ({content: true})});
 
       beforeEach(() => {
-        requestStub = sinon.stub(request, 'putAsync');
+        requestStub = sinon.stub(axios, 'put');
         var mockResponse = {
           statusCode: 200,
           headers: {
@@ -597,10 +599,10 @@ describe('Utils Unit Tests', function() {
       var mockBody = {error: true};
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: request, handleResponse: () => ({content: true})});
+        .create({request: axios, handleResponse: () => ({content: true})});
 
       beforeEach(() => {
-        stub = sinon.stub(request, 'putAsync');
+        stub = sinon.stub(axios, 'put');
         var mockResponse = {
           statusCode: 403,
           headers: {
@@ -633,7 +635,7 @@ describe('Utils Unit Tests', function() {
       var spyPut;
 
       beforeEach(() => {
-        spyPut = sinon.spy(request, 'putAsync');
+        spyPut = sinon.spy(axios, 'put');
       });
 
       afterEach(() => {
@@ -648,25 +650,25 @@ describe('Utils Unit Tests', function() {
           'User-Agent': `smartsheet-javascript-sdk/${EXPECTED_VERSION}`
         };
         requestor.put(sampleRequest);
-        spyPut.args[0][0].headers.Authorization.should.equal(sampleHeaders.Authorization);
-        spyPut.args[0][0].headers.Accept.should.equal(sampleHeaders.Accept);
-        spyPut.args[0][0].headers['Content-Type'].should.equal(sampleHeaders['Content-Type']);
-        spyPut.args[0][0].headers['User-Agent'].should.equal(sampleHeaders['User-Agent']);
+        spyPut.args[0][1].headers.Authorization.should.equal(sampleHeaders.Authorization);
+        spyPut.args[0][1].headers.Accept.should.equal(sampleHeaders.Accept);
+        spyPut.args[0][1].headers['Content-Type'].should.equal(sampleHeaders['Content-Type']);
+        spyPut.args[0][1].headers['User-Agent'].should.equal(sampleHeaders['User-Agent']);
       });
 
       it('url sent to request should match given', () => {
         requestor.put(sampleRequest);
-        spyPut.args[0][0].url.should.equal('https://api.smartsheet.com/2.0/URL');
+        spyPut.args[0][0].should.equal('https://api.smartsheet.com/2.0/URL');
       });
 
       it('queryString sent to request should match given', () => {
         requestor.put(sampleRequestWithQueryParameters);
-        spyPut.args[0][0].qs.should.equal(sampleRequestWithQueryParameters.queryParameters);
+        spyPut.args[0][1].params.should.equal(sampleRequestWithQueryParameters.queryParameters);
       });
 
       it('body sent to request should match given', () => {
         requestor.put(sampleRequestWithQueryParameters);
-        spyPut.args[0][0].body.should.equal(JSON.stringify(sampleRequestWithQueryParameters.body));
+        spyPut.args[0][1].body.should.equal(JSON.stringify(sampleRequestWithQueryParameters.body));
       });
     });
 
@@ -675,7 +677,7 @@ describe('Utils Unit Tests', function() {
       var handleResponseStub = sinon.stub();
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: request, handleResponse: handleResponseStub});
+        .create({request: axios, handleResponse: handleResponseStub});
 
       var sampleRequestForRetry = null;
 
@@ -701,7 +703,7 @@ describe('Utils Unit Tests', function() {
       }
 
       beforeEach(() => {
-        requestStub = sinon.stub(request, 'putAsync');
+        requestStub = sinon.stub(axios, 'put');
 
         sampleRequestForRetry = _.extend({}, sampleRequest);
         sampleRequestForRetry.maxRetryDurationMillis = 30;
@@ -749,10 +751,10 @@ describe('Utils Unit Tests', function() {
       var requestStub = null;
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: request, handleResponse: () => ({content: true})});
+        .create({request: axios, handleResponse: () => ({content: true})});
 
       beforeEach(() => {
-        requestStub = sinon.stub(request, 'delAsync');
+        requestStub = sinon.stub(axios, 'delete');
         var mockResponse = {
           statusCode: 200,
           headers: {
@@ -788,10 +790,10 @@ describe('Utils Unit Tests', function() {
       var mockBody = {error: true};
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: request, handleResponse: () => ({content: true})});
+        .create({request: axios, handleResponse: () => ({content: true})});
 
       beforeEach(() => {
-        requestStub = sinon.stub(request, 'delAsync');
+        requestStub = sinon.stub(axios, 'delete');
         var mockResponse = {
           statusCode: 403,
           headers: {
@@ -824,7 +826,7 @@ describe('Utils Unit Tests', function() {
       var spyPut;
 
       beforeEach(() => {
-        spyPut = sinon.spy(request, 'delAsync');
+        spyPut = sinon.spy(axios, 'delete');
       });
 
       afterEach(() => {
@@ -839,20 +841,20 @@ describe('Utils Unit Tests', function() {
           'User-Agent': `smartsheet-javascript-sdk/${EXPECTED_VERSION}`
         };
         requestor.delete(sampleRequest);
-        spyPut.args[0][0].headers.Authorization.should.equal(sampleHeaders.Authorization);
-        spyPut.args[0][0].headers.Accept.should.equal(sampleHeaders.Accept);
-        spyPut.args[0][0].headers['Content-Type'].should.equal(sampleHeaders['Content-Type']);
-        spyPut.args[0][0].headers['User-Agent'].should.equal(sampleHeaders['User-Agent']);
+        spyPut.args[0][1].headers.Authorization.should.equal(sampleHeaders.Authorization);
+        spyPut.args[0][1].headers.Accept.should.equal(sampleHeaders.Accept);
+        spyPut.args[0][1].headers['Content-Type'].should.equal(sampleHeaders['Content-Type']);
+        spyPut.args[0][1].headers['User-Agent'].should.equal(sampleHeaders['User-Agent']);
       });
 
       it('url sent to request should match given', () => {
         requestor.delete(sampleRequest);
-        spyPut.args[0][0].url.should.equal('https://api.smartsheet.com/2.0/URL');
+        spyPut.args[0][0].should.equal('https://api.smartsheet.com/2.0/URL');
       });
 
       it('queryString sent to request should match given', () => {
         requestor.delete(sampleRequestWithQueryParameters);
-        spyPut.args[0][0].qs.should.equal(sampleRequestWithQueryParameters.queryParameters);
+        spyPut.args[0][1].params.should.equal(sampleRequestWithQueryParameters.queryParameters);
       });
     });
 
@@ -861,7 +863,7 @@ describe('Utils Unit Tests', function() {
       var handleResponseStub = sinon.stub();
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: request, handleResponse: handleResponseStub});
+        .create({request: axios, handleResponse: handleResponseStub});
 
       var sampleRequestForRetry;
 
@@ -887,7 +889,7 @@ describe('Utils Unit Tests', function() {
       }
 
       beforeEach(() => {
-        requestStub = sinon.stub(request, 'delAsync');
+        requestStub = sinon.stub(axios, 'delete');
 
         sampleRequestForRetry = _.extend({}, sampleRequest);
         sampleRequestForRetry.maxRetryDurationMillis = 30;

--- a/test/mock-api/header_test.js
+++ b/test/mock-api/header_test.js
@@ -5,7 +5,7 @@ var helpers = require("./helpers");
 
 describe("Mock API SDK Tests", function() {
   var client = helpers.setupClient();
-
+  
   describe("#Header", function() {
     var scenarios = [
         {

--- a/test/mock-api/helpers.js
+++ b/test/mock-api/helpers.js
@@ -2,6 +2,8 @@ var should = require('should');
 var assert = require('assert');
 var _ = require('underscore');
 var smartsheet = require('../..');
+var sinon = require("sinon");
+var axios = require("axios");
 
 exports.setupClient = function() {
     return smartsheet.createClient({accessToken:'1234', baseUrl: "http://localhost:8082/"});
@@ -15,6 +17,25 @@ exports.defineMockApiTests = function(scenarios) {
 
 var defineMockApiTest = function(scenario) {
     describe('#' + scenario.name, function () {
+        var postStub;
+        var putStub;
+        var getStub;
+        var deleteStub;
+
+        this.beforeAll(() => {
+            postStub = sinon.stub(axios, 'post').resolves({ status: 200, data: true });
+            putStub = sinon.stub(axios, 'put').resolves({ status: 200, data: true });
+            getStub = sinon.stub(axios, 'get').resolves({ status: 200, data: true });
+            deleteStub = sinon.stub(axios, 'delete').resolves({ status: 200, data: true });
+        });
+
+        this.afterAll(() => {
+            postStub.restore();
+            putStub.restore();
+            getStub.restore();
+            deleteStub.restore();
+        });
+
         it('makes request', function () {
             if(_.has(scenario, 'skip')) {
               this.skip(scenario.skip);


### PR DESCRIPTION
This MR removes the dependency on [request](https://www.npmjs.com/package/request) in favor of [axios](https://www.npmjs.com/package/axios). Request has been deprecated for some time and has a vulnerability that they aren't accepting changes to fix. Axios will be a more stable option for the SDK moving forward and provides automatic JSON transformation for responses.

This change also gets us one step closer to removing the [bluebird](https://www.npmjs.com/package/bluebird) dependency. While this package isn't strictly deprecated, it is no longer needed with built in javascript promises. 