### PR TITLE
chore: fix changelog with correct latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [3.1.4] - 2023-08-22
+### Revert
+- Reverted changes in release v3.1.3 as it introduced a bug with PUT/POST requests.
+
+## [3.1.3] - 2023-08-22
+### Security
+- Removed `request` dependency and replaced it with `Axios`
+
 ## [3.1.2] - 2023-06-13
 ### Fixed
 - Added missing euBaseURI constant for smartsheet.eu 


### PR DESCRIPTION
Update the `CHANGELOG` with the release version decided on in the PR as well as correcting the release date.