### PR TITLE
Fix/scmorrison/handle rejections

### DIFF
--- a/lib/utils/httpRequestor.js
+++ b/lib/utils/httpRequestor.js
@@ -161,20 +161,21 @@ exports.create = function(requestorConfig) {
 
   var retryWithBackoffHelper = (url, method, methodName, requestOptions, retryOptions, numRetries) => {
     return error => {
-      var backoffMillis = retryOptions.calcRetryBackoff(numRetries, error);
+      var processedError = handleResponse(error.response);
+      var backoffMillis = retryOptions.calcRetryBackoff(numRetries, processedError);
 
       var shouldExitRetry =
-        !shouldRetry(error) ||
+        !shouldRetry(processedError) ||
         backoffMillis < 0 ||
         Date.now() + backoffMillis >= retryOptions.endRetryTime;
 
       if (shouldExitRetry) {
         logger.logRetryFailure(methodName, requestOptions, numRetries);
-        return new Promise.reject(error);
+        return new Promise.reject(processedError);
       }
 
       var nextRetry = numRetries + 1;
-      logger.logRetryAttempt(methodName, requestOptions, error, nextRetry);
+      logger.logRetryAttempt(methodName, requestOptions, processedError, nextRetry);
       return Promise.delay(backoffMillis)
         .then(() => retryHelper(url, method, methodName, requestOptions, retryOptions, nextRetry));
     };

--- a/lib/utils/responseHandler.js
+++ b/lib/utils/responseHandler.js
@@ -21,7 +21,7 @@ module.exports = (response) => {
       errorResponse.message = response.data;
     }
 
-    return new Promise.reject(errorResponse);
+    return errorResponse;
   }
 
   outResponse.content = response.data;

--- a/test/functional/responseHandler_test.js
+++ b/test/functional/responseHandler_test.js
@@ -36,12 +36,10 @@ describe('Utils Unit Tests', function() {
       it('should return a rejected promise if status code is not 200', () => {
         mockResponse.status = 500;
         mockResponse.data = mockBodyError;
-        handleResponse(mockResponse)
-          .catch(function(error) {
-            error.status.should.equal(500);
-            error.message.should.equal('EMERGENCY');
-            error.errorCode.should.equal(911);
-          });
+        var errResponse = handleResponse(mockResponse);
+        errResponse.statusCode.should.equal(500);
+        errResponse.message.should.equal('EMERGENCY');
+        errResponse.errorCode.should.equal(911);
       });
 
       it('should return parsed JSON body', () => {

--- a/test/functional/utils/responseHandler_test.js
+++ b/test/functional/utils/responseHandler_test.js
@@ -36,19 +36,14 @@ describe('responseHandler', () => {
         data: body
       };
 
-      return responseHandler(response)
-        .then(() => {
-          should.fail('Function should have thrown an error');
-        })
-        .catch((error) => {
-          error.should.have.properties(['statusCode', 'headers', 'errorCode', 'message', 'refId', 'detail']);
-          error.statusCode.should.equal(response.status);
-          error.headers.should.equal(response.headers);
-          error.errorCode.should.equal(body.errorCode);
-          error.message.should.equal(body.message);
-          error.refId.should.equal(body.refId);
-          error.detail.should.equal(body.detail);
-        });
+      var responseError = responseHandler(response);
+      responseError.should.have.properties(['statusCode', 'headers', 'errorCode', 'message', 'refId', 'detail']);
+      responseError.statusCode.should.equal(response.status);
+      responseError.headers.should.equal(response.headers);
+      responseError.errorCode.should.equal(body.errorCode);
+      responseError.message.should.equal(body.message);
+      responseError.refId.should.equal(body.refId);
+      responseError.detail.should.equal(body.detail);
     });
 
     it('should return a rejected promise with an error message for non-JSON response', () => {
@@ -59,16 +54,11 @@ describe('responseHandler', () => {
         data: body
       };
 
-      return responseHandler(response)
-        .then(() => {
-          should.fail('Function should have thrown an error');
-        })
-        .catch(error => {
-          error.should.have.properties(['statusCode', 'headers', 'message']);
-          error.statusCode.should.equal(response.status);
-          error.headers.should.equal(response.headers);
-          error.message.should.equal(body);
-        });
+      var responseError = responseHandler(response);
+      responseError.should.have.properties(['statusCode', 'headers', 'message']);
+      responseError.statusCode.should.equal(response.status);
+      responseError.headers.should.equal(response.headers);
+      responseError.message.should.equal(body);
     });
   });
 });

--- a/test/functional/utils_test.js
+++ b/test/functional/utils_test.js
@@ -312,7 +312,7 @@ describe('Utils Unit Tests', function() {
 
       function givenGetReturnsError() {
         requestStub.returns(Promise.resolve([{}, {}]));
-        handleResponseStub.returns(Promise.reject({errorCode: 4001}));
+        handleResponseStub.returns({errorCode: 4001});
       }
 
       function givenGetReturnsSuccess() {
@@ -493,7 +493,7 @@ describe('Utils Unit Tests', function() {
 
       function givenPostReturnsError() {
         requestStub.returns(Promise.resolve([{}, {}]));
-        handleResponseStub.returns(Promise.reject({errorCode: 4001}));
+        handleResponseStub.returns({errorCode: 4001});
       }
 
       function givenPostReturnsSuccess() {
@@ -683,7 +683,7 @@ describe('Utils Unit Tests', function() {
 
       function givenPutReturnsError() {
         requestStub.returns(Promise.resolve([{}, {}]));
-        handleResponseStub.returns(Promise.reject({errorCode: 4001}));
+        handleResponseStub.returns({errorCode: 4001});
       }
 
       function givenPutReturnsSuccess() {
@@ -869,7 +869,7 @@ describe('Utils Unit Tests', function() {
 
       function givenDeleteReturnsError() {
         requestStub.returns(Promise.resolve([{}, {}]));
-        handleResponseStub.returns(Promise.reject({errorCode: 4001}));
+        handleResponseStub.returns({errorCode: 4001});
       }
 
       function givenDeleteReturnsSuccess() {

--- a/test/functional/utils_test.js
+++ b/test/functional/utils_test.js
@@ -255,13 +255,13 @@ describe('Utils Unit Tests', function() {
       it('request should error as false, using promises', () =>
         stubbedRequestor
           .get(sampleRequest)
-          .catch(error => error.error.should.be.true));
+          .catch(error => error.content.should.be.true));
 
       it('request should error as false, using callbacks', (done) => {
         stubbedRequestor
           .get(sampleRequest,
                (err, data) => {
-                 err.should.be.eql(mockBody);
+                 err.content.should.be.true
                  done();
                 });
       });
@@ -429,13 +429,13 @@ describe('Utils Unit Tests', function() {
       it('request should error as false', () =>
         stubbedRequestor
           .post(sampleRequest)
-          .catch(error => error.error.should.be.true));
+          .catch(error => error.content.should.be.true));
 
       it('request should error as false', (done) => {
         stubbedRequestor
           .post(sampleRequest,
                 (err, data) => {
-                  err.should.be.eql(mockBody);
+                  err.content.should.be.true
                   done();
                 });
       });
@@ -619,13 +619,13 @@ describe('Utils Unit Tests', function() {
       it('request should error as false', () =>
         stubbedRequestor
           .put(sampleRequest)
-          .catch(error => error.error.should.be.true));
+          .catch(error => error.content.should.be.true));
 
       it('request should error as false', (done) => {
         stubbedRequestor
           .put(sampleRequest,
                (err, data) => {
-                 err.should.eql(mockBody);
+                 err.content.should.be.true
                  done();
                 });
       });
@@ -810,13 +810,13 @@ describe('Utils Unit Tests', function() {
       it('request should error as false', () =>
         stubbedRequestor
           .delete(sampleRequest)
-          .catch(error => error.error.should.be.true));
+          .catch(error => error.content.should.be.true));
 
       it('request should error as false', (done) => {
         stubbedRequestor
           .delete(sampleRequest,
                   (err, data) => {
-                    err.should.eql(mockBody);
+                    err.content.should.be.true;
                     done();
                   });
       });


### PR DESCRIPTION
FIX

- fix how we pass the error object to the response handler
- we no longer need to return a promise.reject from response handler
- update tests around response handler and retries for handling errors