### PR TITLE
chore: bump version and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.0.1] - 2023-10-20
+### Fixed
+- Resolved `4.0.0` issue with handling errors
+
 ## [4.0.0] - 2023-10-20
 ### Security
 - Removed `request` dependency and replaced it with `Axios`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smartsheet",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smartsheet",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Smartsheet JavaScript client SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bump version to 4.0.1 and modify changelog for change: https://github.com/smartsheet/smartsheet-javascript-sdk/pull/42