### PR TITLE
fix: generate content-type using file extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.0.2] - 2023-10-23
+### Fixed
+- Resolved [Issue#44](https://github.com/smartsheet/smartsheet-javascript-sdk/issues/44) by using `mime` to generate `Content-Type` based on file extension.
+
 ## [4.0.1] - 2023-10-20
 ### Fixed
 - Resolved `4.0.0` issue with handling errors

--- a/lib/utils/httpRequestor.js
+++ b/lib/utils/httpRequestor.js
@@ -4,6 +4,7 @@ var constants = require('./constants.js');
 var requestLogger = require('./requestLogger');
 var packageJson = require('../../package.json');
 var fs = require('fs');
+var mime = require('mime');
 
 exports.create = function(requestorConfig) {
   var logger = requestorConfig.logger
@@ -32,7 +33,7 @@ exports.create = function(requestorConfig) {
   var buildHeaders = options => {
     var headers = {
       Accept: options.accept || 'application/json',
-      'Content-Type': options.contentType || 'application/json',
+      'Content-Type': options.contentType || mime.getType(options.fileName) || 'application/json',
       'User-Agent': `smartsheet-javascript-sdk/${packageJson.version}`
     };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.4.0",
         "bluebird": "^3.5.0",
         "extend": "^3.0.2",
+        "mime": "^3.0.0",
         "underscore": "^1.8.2",
         "winston": "^2.3.1"
       },
@@ -4887,6 +4888,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -12143,6 +12155,11 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
       }
+    },
+    "mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
     },
     "mime-db": {
       "version": "1.52.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smartsheet",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smartsheet",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Smartsheet JavaScript client SDK",
   "main": "index.js",
   "scripts": {
@@ -33,6 +33,7 @@
     "axios": "^1.4.0",
     "bluebird": "^3.5.0",
     "extend": "^3.0.2",
+    "mime": "^3.0.0",
     "underscore": "^1.8.2",
     "winston": "^2.3.1"
   },

--- a/test/functional/utils_test.js
+++ b/test/functional/utils_test.js
@@ -105,6 +105,8 @@ describe('Utils Unit Tests', function() {
     describe('#buildHeaders', function() {
       var newType = 'text/xml';
       var applicationJson = 'application/json';
+      var textCsv = 'text/csv'
+      var docType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
       var fsStub = null;
 
       beforeEach(() => {
@@ -139,6 +141,21 @@ describe('Utils Unit Tests', function() {
       it('content-type header should equal ' + newType, () => {
         var headers = requestor.internal.buildHeaders({contentType: newType});
         headers['Content-Type'].should.equal(newType);
+      });
+
+      it('Content-Type should equal ' + textCsv, () => {
+        var headers = requestor.internal.buildHeaders({fileName: 'test.csv'});
+        headers['Content-Type'].should.equal(textCsv);
+      });
+
+      it('Content-Type should equal ' + docType, () => {
+        var headers = requestor.internal.buildHeaders({fileName: 'test.docx'});
+        headers['Content-Type'].should.equal(docType);
+      });
+
+      it('Content-Type should equal ' + applicationJson, () => {
+        var headers = requestor.internal.buildHeaders({fileName: 'test'});
+        headers['Content-Type'].should.equal(applicationJson);
       });
 
       it('Content-Disposition should equal filename', () => {


### PR DESCRIPTION
## FIX

Fix issue https://github.com/smartsheet/smartsheet-javascript-sdk/issues/44 which was constantly sending the `Content-Type` header as `application/json`. Import and use the `mime` library to generate this header based on the `fileName` option type e.g. `test.csv` will result in `Content-Type: text/csv`. 