### PR TITLE
fix edge case where calcRetryBackoff isn't defined

### DIFF
--- a/lib/utils/httpRequestor.js
+++ b/lib/utils/httpRequestor.js
@@ -163,7 +163,13 @@ exports.create = function(requestorConfig) {
   var retryWithBackoffHelper = (url, method, methodName, requestOptions, retryOptions, numRetries) => {
     return error => {
       var processedError = handleResponse(error.response);
-      var backoffMillis = retryOptions.calcRetryBackoff(numRetries, processedError);
+
+      var backoffMillis = 0;
+      if (retryOptions.calcRetryBackoff) {
+        backoffMillis = retryOptions.calcRetryBackoff(numRetries, processedError);
+      } else {
+        backoffMillis = defaultCalcBackoff(numRetries);
+      }
 
       var shouldExitRetry =
         !shouldRetry(processedError) ||


### PR DESCRIPTION
Fix for Issue #48 . There was an edge case where the `calcRetryBackoff` function could be undefined throwing an error. I've added a guard against that case that falls back to the default backoff function.