### PR TITLE
chore: Add consistent-type-imports to eslint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,7 +33,7 @@ export default tseslint.config(
           varsIgnorePattern: '^_',
         },
       ],
-      "@typescript-eslint/consistent-type-imports": "error"
+      '@typescript-eslint/consistent-type-imports': 'error',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ export default tseslint.config(
           varsIgnorePattern: '^_',
         },
       ],
+      "@typescript-eslint/consistent-type-imports": "error"
     },
   },
   {

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import { CreateClient, CreateOptions } from './lib/types';
+import type { CreateClient, CreateOptions } from './lib/types';
 import { apiUrls } from './lib/utils/apis';
 import { createEvents } from './lib/events';
 

--- a/lib/events/index.ts
+++ b/lib/events/index.ts
@@ -1,5 +1,5 @@
-import { EventsApi, GetEventsOptions, GetEventsResponse } from './types';
-import { ClientOptions, CreateOptions, RequestCallback, RequestOptions } from '../types';
+import type { EventsApi, GetEventsOptions, GetEventsResponse } from './types';
+import type { ClientOptions, CreateOptions, RequestCallback, RequestOptions } from '../types';
 
 type OptionsToSend = Partial<ClientOptions> & {
   url: string;

--- a/lib/events/types.ts
+++ b/lib/events/types.ts
@@ -1,5 +1,5 @@
-import { RequestCallback } from '../types/RequestCallback';
-import { RequestOptions } from '../types/RequestOptions';
+import type { RequestCallback } from '../types/RequestCallback';
+import type { RequestOptions } from '../types/RequestOptions';
 
 export interface GetEventsOptions {
   /**

--- a/lib/types/CreateClient.ts
+++ b/lib/types/CreateClient.ts
@@ -1,4 +1,4 @@
-import { CreateClientOptions } from './CreateClientOptions';
-import { SmartsheetClient } from './SmartsheetClient';
+import type { CreateClientOptions } from './CreateClientOptions';
+import type { SmartsheetClient } from './SmartsheetClient';
 
 export type CreateClient = (options?: CreateClientOptions) => SmartsheetClient;

--- a/lib/types/CreateClientOptions.ts
+++ b/lib/types/CreateClientOptions.ts
@@ -1,4 +1,4 @@
-import { LoggerInstance } from 'winston';
+import type { LoggerInstance } from 'winston';
 
 export interface CreateClientOptions {
   accessToken?: string;
@@ -8,6 +8,6 @@ export interface CreateClientOptions {
   maxRetryDurationSeconds?: number;
   calcRetryBackoff?: (retryCount: number, error?: any) => number;
   logger?: LoggerInstance;
-  logLevel?: 'error' | 'warn' | 'info' | 'http' | 'info' | 'http' | 'verbose' | 'debug' | 'silly';
+  logLevel?: 'error' | 'warn' | 'info' | 'http' | 'info' | 'verbose' | 'debug' | 'silly';
   loggerContainer?: any;
 }

--- a/lib/types/CreateOptions.ts
+++ b/lib/types/CreateOptions.ts
@@ -1,5 +1,5 @@
-import { ApiUrls } from './ApiUrls';
-import { CreateClientOptions } from './CreateClientOptions';
+import type { ApiUrls } from './ApiUrls';
+import type { CreateClientOptions } from './CreateClientOptions';
 
 export type ClientOptions = Pick<CreateClientOptions, 'accessToken' | 'userAgent' | 'baseUrl'>;
 

--- a/lib/types/RequestCallback.ts
+++ b/lib/types/RequestCallback.ts
@@ -1,3 +1,3 @@
-import { ApiError } from './ApiError';
+import type { ApiError } from './ApiError';
 
 export type RequestCallback<R> = (error?: ApiError, response?: R, body?: any) => void;

--- a/lib/types/SmartsheetClient.ts
+++ b/lib/types/SmartsheetClient.ts
@@ -1,4 +1,4 @@
-import { EventsApi } from '../events/types';
+import type { EventsApi } from '../events/types';
 
 export interface SmartsheetClient {
   constants: any;

--- a/lib/utils/apis.ts
+++ b/lib/utils/apis.ts
@@ -1,4 +1,5 @@
-import { ApiUrls } from '../types';
+import type { ApiUrls } from '../types';
+
 export const apiUrls: ApiUrls = {
   contacts: 'contacts/',
   events: 'events/',


### PR DESCRIPTION
Add `"@typescript-eslint/consistent-type-imports": "error"` to our typescript eslint rules