### PR TITLE
add deprecation tag on the home module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.2.2] - 2025-03-24
+
+
+## [4.2.2] - 2025-04-14
 ### Added
-- Transition from gulp/jshint to eslint/prettier 
+- Transition from gulp/jshint to eslint/prettier
+- Deprecate home module
 
 ## [4.2.1] - 2025-2-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-
-
 ## [4.2.2] - 2025-04-14
 ### Added
 - Transition from gulp/jshint to eslint/prettier

--- a/index.ts
+++ b/index.ts
@@ -94,6 +94,15 @@ export const createClient: CreateClient = function (clientOptions) {
     favorites: require('./lib/favorites/').create(options),
     folders: require('./lib/folders/').create(options),
     groups: require('./lib/groups/').create(options),
+    /**
+     * @deprecated
+     * The home module is deprecated. The endpoints powering this module
+     * are being shut off as part of the sheets folder deprecation.
+     * The endpoints will be available until June.
+     * 
+     * See this changelog entry for more information 
+     * https://developers.smartsheet.com/api/smartsheet/changelog#2025-03-25
+     */
     home: require('./lib/home/').create(options),
     images: require('./lib/images/').create(options),
     reports: require('./lib/reports/').create(options),

--- a/index.ts
+++ b/index.ts
@@ -99,8 +99,8 @@ export const createClient: CreateClient = function (clientOptions) {
      * The home module is deprecated. The endpoints powering this module
      * are being shut off as part of the sheets folder deprecation.
      * The endpoints will be available until June.
-     * 
-     * See this changelog entry for more information 
+     *
+     * See this changelog entry for more information
      * https://developers.smartsheet.com/api/smartsheet/changelog#2025-03-25
      */
     home: require('./lib/home/').create(options),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "Smartsheet JavaScript client SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
The endpoints used to service the home module will stop serving traffic in June. This change marks the home module as deprecated in response. 

See the public api changelog for more details https://developers.smartsheet.com/api/smartsheet/changelog#2025-03-25