### PR TITLE
fix put/post retry issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.2.3] - 2025-05-5
+### Added
+- Fix issue with PUT and POST methods where the body wasn't passed on retries.
+
 ## [4.2.2] - 2025-04-14
 ### Added
 - Transition from gulp/jshint to eslint/prettier

--- a/lib/utils/httpRequestor.js
+++ b/lib/utils/httpRequestor.js
@@ -141,7 +141,7 @@ exports.create = function (requestorConfig) {
   var retryHelper = (url, method, methodName, requestOptions, body, retryOptions, numRetries) => {
     return methodHandler(url, method, methodName, requestOptions, body)
       .then(handleResponse)
-      .catch(retryWithBackoffHelper(url, method, methodName, requestOptions, retryOptions, numRetries));
+      .catch(retryWithBackoffHelper(url, method, methodName, requestOptions, body, retryOptions, numRetries));
   };
 
   var methodHandler = (url, method, methodName, requestOptions, body) => {
@@ -152,7 +152,7 @@ exports.create = function (requestorConfig) {
     return method(url, requestOptions);
   };
 
-  var retryWithBackoffHelper = (url, method, methodName, requestOptions, retryOptions, numRetries) => {
+  var retryWithBackoffHelper = (url, method, methodName, requestOptions, body, retryOptions, numRetries) => {
     return (error) => {
       var processedError = handleResponse(error.response);
 
@@ -174,7 +174,7 @@ exports.create = function (requestorConfig) {
       var nextRetry = numRetries + 1;
       logger.logRetryAttempt(methodName, requestOptions, processedError, nextRetry);
       return Promise.delay(backoffMillis).then(() =>
-        retryHelper(url, method, methodName, requestOptions, retryOptions, nextRetry)
+        retryHelper(url, method, methodName, requestOptions, body, retryOptions, nextRetry)
       );
     };
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smartsheet",
-  "version": "4.2.1",
+  "version": "4.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smartsheet",
-      "version": "4.2.1",
+      "version": "4.2.3",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Smartsheet JavaScript client SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
There is a bug in the retry helper where the body for PUT and POST requests is not passed from the initial `retryHelper` call to the `retryWithBackoffHelper` call. This is causing initial POST/PUT requests to succeed while all retries fail on an empty body. 

This change passes the body all the way down the retry stack to ensure it is included in retry calls.