### PR TITLE
Deprecate and replace workspace and folder endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.4.0] - 2025-08-05
+### Added
+- Added new workspace and folder endpoints.
+  - `getWorkspaceMetadata()` - Returns workspace metadata only
+  - `getWorkspaceChildren()` - Returns workspace child items with token-based pagination
+  - `getFolderMetadata()` - Returns folder metadata only
+  - `getFolderChildren()` - Returns folder child items with token-based pagination
+
+### Deprecated
+- Deprecated the following Workspace and Folder endpoints:
+  - `getWorkspace()` - Use both `getWorkspaceMetadata()` and `getWorkspaceChildren()` instead
+  - `listWorkspaceFolders()` - Use `getWorkspaceChildren()` with `childrenResourceTypes=folders` instead
+  - `getFolder()` - Use both `getFolderMetadata()` and `getFolderChildren()` instead
+  - `listChildFolders()` - Use `getFolderChildren()` with `childrenResourceTypes=folders` instead
+- Deprecated the Home endpoints. See the [Migrate from using the Sheets folder](https://developers.smartsheet.com/api/smartsheet/guides/updating-code/migrate-from-using-the-sheets-folder) page on the API site for guidance on adapting to this deprecation. The deprecated endpoints are:
+  - `listContents()`
+  - `listFolders()`
+  - `createFolder()`
+
 ## [4.3.0] - 2025-26-27
 ### Added
 - ESLint Rule for enforcing type imports.
@@ -60,7 +79,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [3.1.2] - 2023-06-13
 ### Fixed
-- Added missing euBaseURI constant for smartsheet.eu 
+- Added missing euBaseURI constant for smartsheet.eu
 ## [3.1.1] - 2023-06-07
 ### Added
 - Developer program agreement note to README
@@ -70,7 +89,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for reactivate user endpoint
 ## [3.0.0] - 2022-12-05
 ### Updated
-- Migrated SDK to new project 
+- Migrated SDK to new project
 - Update supported versions to 14, 16 and 18
 ### Added
 - Add Github Actions pipeline

--- a/lib/folders/index.js
+++ b/lib/folders/index.js
@@ -13,6 +13,7 @@ exports.create = function (options) {
    * @deprecated Use both getFolderMetadata and getFolderChildren instead.
    */
   var getFolder = (getOptions, callback) => {
+    console.warn('DEPRECATED: Folders.getFolder is deprecated. Use getFolderMetadata and getFolderChildren instead.');
     return requestor.get(_.extend({}, optionsToSend, getOptions), callback);
   };
 
@@ -20,6 +21,7 @@ exports.create = function (options) {
    * @deprecated Use getFolderChildren with childrenResourceTypes=folders instead.
    */
   var listChildFolders = (getOptions, callback) => {
+    console.warn('DEPRECATED: Folders.listChildFolders is deprecated. Use getFolderChildren instead.');
     var urlOptions = { url: options.apiUrls.folders + getOptions.folderId + '/folders' };
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };

--- a/lib/folders/index.js
+++ b/lib/folders/index.js
@@ -9,8 +9,16 @@ exports.create = function (options) {
   };
   _.extend(optionsToSend, options.clientOptions);
 
-  var getFolder = (getOptions, callback) => requestor.get(_.extend({}, optionsToSend, getOptions), callback);
+  /**
+   * @deprecated Use both getFolderMetadata and getFolderChildren instead.
+   */
+  var getFolder = (getOptions, callback) => {
+    return requestor.get(_.extend({}, optionsToSend, getOptions), callback);
+  };
 
+  /**
+   * @deprecated Use getFolderChildren with childrenResourceTypes=folders instead.
+   */
   var listChildFolders = (getOptions, callback) => {
     var urlOptions = { url: options.apiUrls.folders + getOptions.folderId + '/folders' };
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
@@ -36,8 +44,39 @@ exports.create = function (options) {
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
+  /**
+   * Get metadata of a folder
+   * @param {Object} getOptions - Options including folderId and optional query parameters
+   * @param {number} getOptions.folderId - The folder ID
+   * @param {Object} [getOptions.queryParameters] - Optional query parameters
+   * @param {string} [getOptions.queryParameters.include] - Comma-separated list of fields to include (source)
+   * @param {Function} callback - Callback function
+   */
+  var getFolderMetadata = (getOptions, callback) => {
+    var urlOptions = { url: options.apiUrls.folders + getOptions.folderId + '/metadata' };
+    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
+  };
+
+  /**
+   * Get children of a folder with token-based pagination
+   * @param {Object} getOptions - Options including folderId and optional query parameters
+   * @param {number} getOptions.folderId - The folder ID
+   * @param {Object} [getOptions.queryParameters] - Optional query parameters
+   * @param {string} [getOptions.queryParameters.childrenResourceTypes] - Filter by resource type(s) (sheets, reports, sights, folders). Comma-separated string of types.
+   * @param {string} [getOptions.queryParameters.include] - Comma-separated list of fields to include (source, ownerInfo)
+   * @param {number} [getOptions.queryParameters.maxItems] - Maximum items per page
+   * @param {string} [getOptions.queryParameters.lastKey] - Token for pagination
+   * @param {Function} callback - Callback function
+   */
+  var getFolderChildren = (getOptions, callback) => {
+    var urlOptions = { url: options.apiUrls.folders + getOptions.folderId + '/children' };
+    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
+  };
+
   return {
     getFolder: getFolder,
+    getFolderMetadata: getFolderMetadata,
+    getFolderChildren: getFolderChildren,
     listChildFolders: listChildFolders,
     createChildFolder: createChildFolder,
     updateFolder: updateFolder,

--- a/lib/home/index.js
+++ b/lib/home/index.js
@@ -9,20 +9,26 @@ exports.create = function (options) {
   _.extend(optionsToSend, options.clientOptions);
 
   /**
-   * @deprecated This method is deprecated.
+   * @deprecated See: https://developers.smartsheet.com/api/smartsheet/guides/updating-code/migrate-from-using-the-sheets-folder
    */
-  var listContents = (getOptions, callback) => requestor.get(_.extend({}, optionsToSend, getOptions), callback);
+  var listContents = (getOptions, callback) => {
+    console.warn('DEPRECATED: Home.listContents is deprecated.');
+    return requestor.get(_.extend({}, optionsToSend, getOptions), callback);
+  }
 
   /**
-   * @deprecated This method is deprecated.
+   * @deprecated See: https://developers.smartsheet.com/api/smartsheet/guides/updating-code/migrate-from-using-the-sheets-folder
    */
-  var listFolders = (getOptions, callback) =>
-    listContents(_.extend({ url: options.apiUrls.home + 'folders' }, getOptions), callback);
+  var listFolders = (getOptions, callback) => {
+    console.warn('DEPRECATED: Home.listFolders is deprecated.');
+    return listContents(_.extend({ url: options.apiUrls.home + 'folders' }, getOptions), callback);
+  }
 
   /**
-   * @deprecated This method is deprecated.
+   * @deprecated See: https://developers.smartsheet.com/api/smartsheet/guides/updating-code/migrate-from-using-the-sheets-folder
    */
   var createFolder = (postOptions, callback) => {
+    console.warn('DEPRECATED: Home.createFolder is deprecated.');
     var urlOptions = { url: options.apiUrls.home + 'folders' };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };

--- a/lib/home/index.js
+++ b/lib/home/index.js
@@ -14,7 +14,7 @@ exports.create = function (options) {
   var listContents = (getOptions, callback) => {
     console.warn('DEPRECATED: Home.listContents is deprecated.');
     return requestor.get(_.extend({}, optionsToSend, getOptions), callback);
-  }
+  };
 
   /**
    * @deprecated See: https://developers.smartsheet.com/api/smartsheet/guides/updating-code/migrate-from-using-the-sheets-folder
@@ -22,7 +22,7 @@ exports.create = function (options) {
   var listFolders = (getOptions, callback) => {
     console.warn('DEPRECATED: Home.listFolders is deprecated.');
     return listContents(_.extend({ url: options.apiUrls.home + 'folders' }, getOptions), callback);
-  }
+  };
 
   /**
    * @deprecated See: https://developers.smartsheet.com/api/smartsheet/guides/updating-code/migrate-from-using-the-sheets-folder

--- a/lib/home/index.js
+++ b/lib/home/index.js
@@ -8,11 +8,20 @@ exports.create = function (options) {
   };
   _.extend(optionsToSend, options.clientOptions);
 
+  /**
+   * @deprecated This method is deprecated.
+   */
   var listContents = (getOptions, callback) => requestor.get(_.extend({}, optionsToSend, getOptions), callback);
 
+  /**
+   * @deprecated This method is deprecated.
+   */
   var listFolders = (getOptions, callback) =>
     listContents(_.extend({ url: options.apiUrls.home + 'folders' }, getOptions), callback);
 
+  /**
+   * @deprecated This method is deprecated.
+   */
   var createFolder = (postOptions, callback) => {
     var urlOptions = { url: options.apiUrls.home + 'folders' };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);

--- a/lib/workspaces/index.js
+++ b/lib/workspaces/index.js
@@ -18,6 +18,7 @@ exports.create = function (options) {
    * @deprecated Use getWorkspaceChildren with childrenResourceTypes=folders instead.
    */
   var listWorkspaceFolders = (getOptions, callback) => {
+    console.warn('DEPRECATED: Workspaces.listWorkspaceFolders is deprecated. Use getWorkspaceChildren instead.');
     var urlOptions = { url: buildUrl(getOptions) + '/folders' };
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };

--- a/lib/workspaces/index.js
+++ b/lib/workspaces/index.js
@@ -14,6 +14,9 @@ exports.create = function (options) {
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 
+  /**
+   * @deprecated Use getWorkspaceChildren with childrenResourceTypes=folders instead.
+   */
   var listWorkspaceFolders = (getOptions, callback) => {
     var urlOptions = { url: buildUrl(getOptions) + '/folders' };
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
@@ -44,6 +47,35 @@ exports.create = function (options) {
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
+  /**
+   * Get metadata of a workspace
+   * @param {Object} getOptions - Options including workspaceId and optional query parameters
+   * @param {number} getOptions.workspaceId - The workspace ID
+   * @param {Object} [getOptions.queryParameters] - Optional query parameters
+   * @param {string} [getOptions.queryParameters.include] - Comma-separated list of fields to include (source)
+   * @param {Function} callback - Callback function
+   */
+  var getWorkspaceMetadata = (getOptions, callback) => {
+    var urlOptions = { url: buildUrl(getOptions) + '/metadata' };
+    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
+  };
+
+  /**
+   * Get children of a workspace with token-based pagination
+   * @param {Object} getOptions - Options including workspaceId and optional query parameters
+   * @param {number} getOptions.workspaceId - The workspace ID
+   * @param {Object} [getOptions.queryParameters] - Optional query parameters
+   * @param {string} [getOptions.queryParameters.childrenResourceTypes] - Filter by resource type(s) (sheets, reports, sights, folders). Comma-separated string of types.
+   * @param {string} [getOptions.queryParameters.include] - Comma-separated list of fields to include (source, ownerInfo)
+   * @param {number} [getOptions.queryParameters.maxItems] - Maximum items per page
+   * @param {string} [getOptions.queryParameters.lastKey] - Token for pagination
+   * @param {Function} callback - Callback function
+   */
+  var getWorkspaceChildren = (getOptions, callback) => {
+    var urlOptions = { url: buildUrl(getOptions) + '/children' };
+    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
+  };
+
   var buildUrl = (urlOptions) => {
     var id = '';
     if (urlOptions && urlOptions.workspaceId) {
@@ -55,6 +87,8 @@ exports.create = function (options) {
   var workspaceObject = {
     listWorkspaces: listWorkspaces,
     getWorkspace: listWorkspaces,
+    getWorkspaceMetadata: getWorkspaceMetadata,
+    getWorkspaceChildren: getWorkspaceChildren,
     listWorkspaceFolders: listWorkspaceFolders,
     createWorkspace: createWorkspace,
     createFolder: createFolder,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smartsheet",
-  "version": "4.2.3",
+  "version": "4.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smartsheet",
-      "version": "4.2.3",
+      "version": "4.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Smartsheet JavaScript client SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/test/functional/client_test.js
+++ b/test/functional/client_test.js
@@ -88,11 +88,13 @@ describe('Client Unit Tests', function() {
   describe('#folders', function() {
     it('should have folders object',function(){
       smartsheet.should.have.property('folders');
-      Object.keys(smartsheet.folders).should.be.length(7);
+      Object.keys(smartsheet.folders).should.be.length(9);
     });
 
     it('should have get methods', function() {
       smartsheet.folders.should.have.property('getFolder');
+      smartsheet.folders.should.have.property('getFolderMetadata');
+      smartsheet.folders.should.have.property('getFolderChildren');
       smartsheet.folders.should.have.property('listChildFolders');
     });
 
@@ -101,7 +103,7 @@ describe('Client Unit Tests', function() {
       smartsheet.folders.should.have.property('copyFolder');
     });
 
-    it('should have Sheets update methods', function() {
+    it('should have update methods', function() {
       smartsheet.folders.should.have.property('updateFolder');
       smartsheet.folders.should.have.property('moveFolder');
     });
@@ -425,13 +427,15 @@ describe('Client Unit Tests', function() {
   describe('#workspaces', function () {
     it('should have workspaces object', function () {
       smartsheet.should.have.property('workspaces');
-      Object.keys(smartsheet.workspaces).should.be.length(13);
+      Object.keys(smartsheet.workspaces).should.be.length(15);
     });
 
     it('should have get methods', function () {
       smartsheet.workspaces.should.have.property('getShare');
       smartsheet.workspaces.should.have.property('listShares');
       smartsheet.workspaces.should.have.property('getWorkspace');
+      smartsheet.workspaces.should.have.property('getWorkspaceMetadata');
+      smartsheet.workspaces.should.have.property('getWorkspaceChildren');
       smartsheet.workspaces.should.have.property('listWorkspaceFolders');
       smartsheet.workspaces.should.have.property('listWorkspaces');
     });

--- a/test/functional/endpoints_test.js
+++ b/test/functional/endpoints_test.js
@@ -57,6 +57,8 @@ describe('Method Unit Tests', function () {
             name: 'folders',
             methods: [
                 { name: 'getFolder', stub: 'get', options: {}, expectedRequest: {url: "folders/" }},
+                { name: 'getFolderMetadata', stub: 'get', options: {folderId: 123}, expectedRequest: {url: "folders/123/metadata" }},
+                { name: 'getFolderChildren', stub: 'get', options: {folderId: 123}, expectedRequest: {url: "folders/123/children" }},
                 { name: 'listChildFolders', stub: 'get', options: {folderId: 123}, expectedRequest: {url: "folders/123/folders" }},
                 { name: 'createChildFolder', stub: 'post', options: {folderId: 123}, expectedRequest: {url: "folders/123/folders" }},
                 { name: 'updateFolder', stub: 'put', options: {folderId: 123}, expectedRequest: {url: "folders/" }},
@@ -312,6 +314,8 @@ describe('Method Unit Tests', function () {
             methods: [
                 { name: 'listWorkspaces', stub: 'get', options: undefined, expectedRequest: {url: "workspaces/"}},
                 { name: 'getWorkspace', stub: 'get', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123"}},
+                { name: 'getWorkspaceMetadata', stub: 'get', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123/metadata"}},
+                { name: 'getWorkspaceChildren', stub: 'get', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123/children"}},
                 { name: 'listWorkspaceFolders', stub: 'get', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123/folders"}},
                 { name: 'createWorkspace', stub: 'post', options: {}, expectedRequest: {url: "workspaces/"}},
                 { name: 'createFolder', stub: 'post', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123/folders"}},

--- a/test/mock-api/folders_test.js
+++ b/test/mock-api/folders_test.js
@@ -1,0 +1,76 @@
+var sinon = require('sinon');
+var should = require('should');
+var assert = require('assert');
+var helpers = require('./helpers');
+
+describe('Mock API SDK Tests - Folder Endpoints', function() {
+  var client = helpers.setupClient();
+
+  describe('#Folders', function() {
+    var scenarios = [
+      {
+        "name": "Get Folder Metadata - No Params",
+        "method": client.folders.getFolderMetadata,
+        "shouldError": false,
+        "options": {
+          "folderId": 456
+        }
+      },
+      {
+        "name": "Get Folder Metadata - Include Source",
+        "method": client.folders.getFolderMetadata,
+        "shouldError": false,
+        "options": {
+          "folderId": 456,
+          "queryParameters": {
+            "include": "source"
+          }
+        }
+      },
+      {
+        "name": "Get Folder Children - No Params",
+        "method": client.folders.getFolderChildren,
+        "shouldError": false,
+        "options": {
+          "folderId": 456
+        }
+      },
+      {
+        "name": "Get Folder Children - Include Source and OwnerInfo",
+        "method": client.folders.getFolderChildren,
+        "shouldError": false,
+        "options": {
+          "folderId": 456,
+          "queryParameters": {
+            "include": "source,ownerInfo"
+          }
+        }
+      },
+      {
+        "name": "Get Folder Children - Filter Sights and Reports",
+        "method": client.folders.getFolderChildren,
+        "shouldError": false,
+        "options": {
+          "folderId": 456,
+          "queryParameters": {
+            "childrenResourceTypes": "reports,sights"
+          }
+        }
+      },
+      {
+        "name": "Get Folder Children - MaxItems and LastKey",
+        "method": client.folders.getFolderChildren,
+        "shouldError": false,
+        "options": {
+          "folderId": 456,
+          "queryParameters": {
+            "maxItems": "100",
+            "lastKey": "aslkjf4wlkta4n4900sjfklf499sjwlk4356lkj"
+          }
+        }
+      }
+    ];
+
+    helpers.defineMockApiTests(scenarios);
+  });
+});

--- a/test/mock-api/workspaces_test.js
+++ b/test/mock-api/workspaces_test.js
@@ -1,0 +1,76 @@
+var sinon = require('sinon');
+var should = require('should');
+var assert = require('assert');
+var helpers = require('./helpers');
+
+describe('Mock API SDK Tests - Workspace Endpoints', function() {
+  var client = helpers.setupClient();
+
+  describe('#Workspaces', function() {
+    var scenarios = [
+      {
+        "name": "Get Workspace Metadata - No Params",
+        "method": client.workspaces.getWorkspaceMetadata,
+        "shouldError": false,
+        "options": {
+          "workspaceId": 123
+        }
+      },
+      {
+        "name": "Get Workspace Metadata - Include Source",
+        "method": client.workspaces.getWorkspaceMetadata,
+        "shouldError": false,
+        "options": {
+          "workspaceId": 123,
+          "queryParameters": {
+            "include": "source"
+          }
+        }
+      },
+      {
+        "name": "Get Workspace Children - No Params",
+        "method": client.workspaces.getWorkspaceChildren,
+        "shouldError": false,
+        "options": {
+          "workspaceId": 123
+        }
+      },
+      {
+        "name": "Get Workspace Children - Include Source and OwnerInfo",
+        "method": client.workspaces.getWorkspaceChildren,
+        "shouldError": false,
+        "options": {
+          "workspaceId": 123,
+          "queryParameters": {
+            "include": "source,ownerInfo"
+          }
+        }
+      },
+      {
+        "name": "Get Workspace Children - Filter Sheets and Folders",
+        "method": client.workspaces.getWorkspaceChildren,
+        "shouldError": false,
+        "options": {
+          "workspaceId": 123,
+          "queryParameters": {
+            "childrenResourceTypes": "folders,sheets"
+          }
+        }
+      },
+      {
+        "name": "Get Workspace Children - MaxItems and LastKey",
+        "method": client.workspaces.getWorkspaceChildren,
+        "shouldError": false,
+        "options": {
+          "workspaceId": 123,
+          "queryParameters": {
+            "maxItems": "1000",
+            "lastKey": "aslkjf4wlkta4n4900sjfklf499sjwlk4356lkj"
+          }
+        }
+      }
+    ];
+
+    helpers.defineMockApiTests(scenarios);
+  });
+});


### PR DESCRIPTION
## Description:
Deprecates GetWorkspace and GetFolder endpoints along with a few Home endpoints. Adds new workspace and folder endpoints that fetch metadata and children separately:
* getWorkspaceMetadata()
* getWorkspaceChildren()
* getFolderMetadata()
* getFolderChildren()

See changelog for more info. 

## Testing 
Passes `npm run test`.