### PR TITLE
Add support for user upgrade & downgrade APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.3.0] - 2025-08-12
+### Added
+- Add support for upgrade/downgrade endpoints
+
 ## [4.3.0] - 2025-26-27
 ### Added
 - ESLint Rule for enforcing type imports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.3.0] - 2025-08-12
+## [4.4.0] - 2025-08-12
 ### Added
 - Add support for upgrade/downgrade endpoints
 

--- a/lib/users/index.js
+++ b/lib/users/index.js
@@ -45,6 +45,11 @@ exports.create = function (options) {
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
+  var downgradeUserPlan = (postOptions, callback) => {
+    var urlOptions = { url: buildSeatTypePlanDowngradeUrl(postOptions) };
+    return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
+  };
+
   var buildProfileImageUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/profileimage';
 
   var buildDeactivateUserUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/deactivate';
@@ -52,6 +57,8 @@ exports.create = function (options) {
   var buildReactivateUserUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/reactivate';
 
   var buildSeatTypePlanUpgradeUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId + '/upgrade';
+  
+  var buildSeatTypePlanDowngradeUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId + '/downgrade';
 
   var userObject = {
     getUser: listAllUsers,
@@ -65,6 +72,7 @@ exports.create = function (options) {
     reactivateUser: reactivateUser,
     addProfileImage: addProfileImage,
     upgradeUserPlan: upgradeUserPlan,
+    downgradeUserPlan: downgradeUserPlan,
   };
 
   _.extend(userObject, alternateEmails.create(options));

--- a/lib/users/index.js
+++ b/lib/users/index.js
@@ -40,11 +40,18 @@ exports.create = function (options) {
     return requestor.postFile(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
+  var upgradeUserPlan = (postOptions, callback) => {
+    var urlOptions = { url: buildSeatTypePlanUpgradeUrl(postOptions) };
+    return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
+  };
+
   var buildProfileImageUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/profileimage';
 
   var buildDeactivateUserUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/deactivate';
 
   var buildReactivateUserUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/reactivate';
+
+  var buildSeatTypePlanUpgradeUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId + '/upgrade';
 
   var userObject = {
     getUser: listAllUsers,
@@ -57,6 +64,7 @@ exports.create = function (options) {
     deactivateUser: deactivateUser,
     reactivateUser: reactivateUser,
     addProfileImage: addProfileImage,
+    upgradeUserPlan: upgradeUserPlan,
   };
 
   _.extend(userObject, alternateEmails.create(options));

--- a/lib/users/index.js
+++ b/lib/users/index.js
@@ -40,13 +40,13 @@ exports.create = function (options) {
     return requestor.postFile(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
-  var upgradeUserPlan = (postOptions, callback) => {
-    var urlOptions = { url: buildSeatTypePlanUpgradeUrl(postOptions) };
+  var upgradeUserForPlan = (postOptions, callback) => {
+    var urlOptions = { url: buildUserUpgradeForPlanUrl(postOptions) };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
-  var downgradeUserPlan = (postOptions, callback) => {
-    var urlOptions = { url: buildSeatTypePlanDowngradeUrl(postOptions) };
+  var downgradeUserForPlan = (postOptions, callback) => {
+    var urlOptions = { url: buildUserDowngradeForPlanUrl(postOptions) };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
@@ -56,9 +56,9 @@ exports.create = function (options) {
 
   var buildReactivateUserUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/reactivate';
 
-  var buildSeatTypePlanUpgradeUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId + '/upgrade';
+  var buildUserUpgradeForPlanUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId + '/upgrade';
   
-  var buildSeatTypePlanDowngradeUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId + '/downgrade';
+  var buildUserDowngradeForPlanUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId + '/downgrade';
 
   var userObject = {
     getUser: listAllUsers,
@@ -71,8 +71,8 @@ exports.create = function (options) {
     deactivateUser: deactivateUser,
     reactivateUser: reactivateUser,
     addProfileImage: addProfileImage,
-    upgradeUserPlan: upgradeUserPlan,
-    downgradeUserPlan: downgradeUserPlan,
+    upgradeUserForPlan: upgradeUserForPlan,
+    downgradeUserForPlan: downgradeUserForPlan,
   };
 
   _.extend(userObject, alternateEmails.create(options));

--- a/lib/users/index.js
+++ b/lib/users/index.js
@@ -56,9 +56,11 @@ exports.create = function (options) {
 
   var buildReactivateUserUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/reactivate';
 
-  var buildUserUpgradeForPlanUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId + '/upgrade';
-  
-  var buildUserDowngradeForPlanUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId + '/downgrade';
+  var buildUserUpgradeForPlanUrl = (urlOptions) =>
+    options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId + '/upgrade';
+
+  var buildUserDowngradeForPlanUrl = (urlOptions) =>
+    options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId + '/downgrade';
 
   var userObject = {
     getUser: listAllUsers,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Smartsheet JavaScript client SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/test/functional/client_test.js
+++ b/test/functional/client_test.js
@@ -366,7 +366,7 @@ describe('Client Unit Tests', function() {
   describe('#users', function () {
     it('should have user object', function () {
       smartsheet.should.have.property('users');
-      Object.keys(smartsheet.users).should.be.length(15);
+      Object.keys(smartsheet.users).should.be.length(16);
     });
 
     it('should have get methods', function () {

--- a/test/functional/client_test.js
+++ b/test/functional/client_test.js
@@ -366,7 +366,7 @@ describe('Client Unit Tests', function() {
   describe('#users', function () {
     it('should have user object', function () {
       smartsheet.should.have.property('users');
-      Object.keys(smartsheet.users).should.be.length(16);
+      Object.keys(smartsheet.users).should.be.length(17);
     });
 
     it('should have get methods', function () {

--- a/test/functional/endpoints_test.js
+++ b/test/functional/endpoints_test.js
@@ -286,6 +286,7 @@ describe('Method Unit Tests', function () {
                 { name: 'removeUser', stub: 'delete', options: {}, expectedRequest: {url: "users/"}},
                 { name: 'deactivateUser', stub: 'post', options: {userId: 123}, expectedRequest: {url: "users/123/deactivate"}},
                 { name: 'reactivateUser', stub: 'post', options: {userId: 123}, expectedRequest: {url: "users/123/reactivate"}},
+                { name: 'upgradeUserPlan', stub: 'post', options: {userId: 123, planId: 456, body: {seatType: 'MEMBER'}}, expectedRequest: {url: "users/123/plans/456/upgrade", body: {seatType: 'MEMBER'}}},
                 // alternate emails
                 { name: 'addAlternateEmail', stub: 'post', options: {userId: 123}, expectedRequest: {url: "users/123/alternateemails/"}},
                 { name: 'getAlternateEmail', stub: 'get', options: {userId: 123, alternateEmailId: 234}, expectedRequest: {url: "users/123/alternateemails/234"}},

--- a/test/functional/endpoints_test.js
+++ b/test/functional/endpoints_test.js
@@ -286,8 +286,8 @@ describe('Method Unit Tests', function () {
                 { name: 'removeUser', stub: 'delete', options: {}, expectedRequest: {url: "users/"}},
                 { name: 'deactivateUser', stub: 'post', options: {userId: 123}, expectedRequest: {url: "users/123/deactivate"}},
                 { name: 'reactivateUser', stub: 'post', options: {userId: 123}, expectedRequest: {url: "users/123/reactivate"}},
-                { name: 'upgradeUserPlan', stub: 'post', options: {userId: 123, planId: 456, body: {seatType: 'MEMBER'}}, expectedRequest: {url: "users/123/plans/456/upgrade", body: {seatType: 'MEMBER'}}},
-                { name: 'downgradeUserPlan', stub: 'post', options: {userId: 123, planId: 456, body: {seatType: 'VIEWER'}}, expectedRequest: {url: "users/123/plans/456/downgrade", body: {seatType: 'VIEWER'}}},
+                { name: 'upgradeUserForPlan', stub: 'post', options: {userId: 123, planId: 456, body: {seatType: 'MEMBER'}}, expectedRequest: {url: "users/123/plans/456/upgrade", body: {seatType: 'MEMBER'}}},
+                { name: 'downgradeUserForPlan', stub: 'post', options: {userId: 123, planId: 456, body: {seatType: 'VIEWER'}}, expectedRequest: {url: "users/123/plans/456/downgrade", body: {seatType: 'VIEWER'}}},
                 // alternate emails
                 { name: 'addAlternateEmail', stub: 'post', options: {userId: 123}, expectedRequest: {url: "users/123/alternateemails/"}},
                 { name: 'getAlternateEmail', stub: 'get', options: {userId: 123, alternateEmailId: 234}, expectedRequest: {url: "users/123/alternateemails/234"}},

--- a/test/functional/endpoints_test.js
+++ b/test/functional/endpoints_test.js
@@ -287,6 +287,7 @@ describe('Method Unit Tests', function () {
                 { name: 'deactivateUser', stub: 'post', options: {userId: 123}, expectedRequest: {url: "users/123/deactivate"}},
                 { name: 'reactivateUser', stub: 'post', options: {userId: 123}, expectedRequest: {url: "users/123/reactivate"}},
                 { name: 'upgradeUserPlan', stub: 'post', options: {userId: 123, planId: 456, body: {seatType: 'MEMBER'}}, expectedRequest: {url: "users/123/plans/456/upgrade", body: {seatType: 'MEMBER'}}},
+                { name: 'downgradeUserPlan', stub: 'post', options: {userId: 123, planId: 456, body: {seatType: 'VIEWER'}}, expectedRequest: {url: "users/123/plans/456/downgrade", body: {seatType: 'VIEWER'}}},
                 // alternate emails
                 { name: 'addAlternateEmail', stub: 'post', options: {userId: 123}, expectedRequest: {url: "users/123/alternateemails/"}},
                 { name: 'getAlternateEmail', stub: 'get', options: {userId: 123, alternateEmailId: 234}, expectedRequest: {url: "users/123/alternateemails/234"}},

--- a/test/mock-api/serialization_test.js
+++ b/test/mock-api/serialization_test.js
@@ -538,8 +538,8 @@ describe("Mock API SDK Tests", function() {
                 }
             },
             {
-                name: "Serialization - UpgradeUserPlan",
-                method: client.users.upgradeUserPlan,
+                name: "Serialization - upgradeUserForPlan",
+                method: client.users.upgradeUserForPlan,
                 shouldError: false,
                 options: {
                     userId: 123,
@@ -548,8 +548,8 @@ describe("Mock API SDK Tests", function() {
                 }
             },
             {
-                name: "Serialization - DowngradeUserPlan",
-                method: client.users.downgradeUserPlan,
+                name: "Serialization - downgradeUserForPlan",
+                method: client.users.downgradeUserForPlan,
                 shouldError: false,
                 options: {
                     userId: 123,

--- a/test/mock-api/serialization_test.js
+++ b/test/mock-api/serialization_test.js
@@ -536,6 +536,16 @@ describe("Mock API SDK Tests", function() {
                         "endColumnId": 6
                     }
                 }
+            },
+            {
+                name: "Serialization - UpgradeUserPlan",
+                method: client.users.upgradeUserPlan,
+                shouldError: false,
+                options: {
+                    userId: 123,
+                    planId: 456,
+                    body: { seatType: "MEMBER" }
+                }
             }
         ];
 

--- a/test/mock-api/serialization_test.js
+++ b/test/mock-api/serialization_test.js
@@ -546,6 +546,16 @@ describe("Mock API SDK Tests", function() {
                     planId: 456,
                     body: { seatType: "MEMBER" }
                 }
+            },
+            {
+                name: "Serialization - DowngradeUserPlan",
+                method: client.users.downgradeUserPlan,
+                shouldError: false,
+                options: {
+                    userId: 123,
+                    planId: 456,
+                    body: { seatType: "VIEWER" }
+                }
             }
         ];
 


### PR DESCRIPTION
Added support for user upgrade/downgrade endpoints:
POST /users/{userId}/plans/{planId}/upgrade
POST /users/{userId}/plans/{planId}/downgrade