### PR TITLE
Introduce Smartsheet-Integration-Source request header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.3.1] - 2025-08-18
+### Added
+- Support for the `Smartsheet-Integration-Source` header. This can be configured using the `httpRequestor.js`.
+
 ## [4.3.0] - 2025-26-27
 ### Added
 - ESLint Rule for enforcing type imports.

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,7 @@ import { createContacts } from './lib/contacts';
 import { createEvents } from './lib/events';
 import { createSearch } from './lib/search';
 import { createSights } from './lib/sights';
+import { isValidFormat } from './lib/utils/smartsheetIntegrationSourceValidator';
 
 const _ = require('underscore');
 const winston = require('winston');
@@ -78,6 +79,9 @@ function buildLoggerFromContainer(container) {
 }
 
 export const createClient: CreateClient = function (clientOptions) {
+  // Validate smartsheetIntegrationSource header if provided
+  isValidFormat(clientOptions.smartsheetIntegrationSource);
+
   const requestor = buildRequestor(clientOptions);
 
   const options: CreateOptions = {
@@ -87,6 +91,7 @@ export const createClient: CreateClient = function (clientOptions) {
       accessToken: clientOptions.accessToken || process.env.SMARTSHEET_ACCESS_TOKEN,
       userAgent: clientOptions.userAgent,
       baseUrl: clientOptions.baseUrl,
+      smartsheetIntegrationSource: clientOptions.smartsheetIntegrationSource,
     },
   };
 

--- a/lib/types/CreateClientOptions.ts
+++ b/lib/types/CreateClientOptions.ts
@@ -4,6 +4,7 @@ export interface CreateClientOptions {
   accessToken?: string;
   userAgent?: string;
   baseUrl?: string;
+  smartsheetIntegrationSource: string;
   requestor?: any; // Custom HTTP client that will be used. TODO -> Evaluate if we want to keep this.
   maxRetryDurationSeconds?: number;
   calcRetryBackoff?: (retryCount: number, error?: any) => number;

--- a/lib/types/CreateOptions.ts
+++ b/lib/types/CreateOptions.ts
@@ -1,7 +1,7 @@
 import type { ApiUrls } from './ApiUrls';
 import type { CreateClientOptions } from './CreateClientOptions';
 
-export type ClientOptions = Pick<CreateClientOptions, 'accessToken' | 'userAgent' | 'baseUrl'>;
+export type ClientOptions = Pick<CreateClientOptions, 'accessToken' | 'userAgent' | 'baseUrl' | 'smartsheetIntegrationSource'>;
 
 export interface CreateOptions {
   apiUrls: ApiUrls;

--- a/lib/utils/httpRequestor.js
+++ b/lib/utils/httpRequestor.js
@@ -60,6 +60,9 @@ exports.create = function (requestorConfig) {
     if (options.changeAgent) {
       headers['Smartsheet-Change-Agent'] = options.changeAgent;
     }
+    if (options.smartsheetIntegrationSource) {
+      headers['Smartsheet-Integration-Source'] = options.smartsheetIntegrationSource;
+    }
     if (options.customProperties) {
       for (const [key, value] of Object.entries(options.customProperties)) {
         headers[key] = value;

--- a/lib/utils/httpRequestor.js
+++ b/lib/utils/httpRequestor.js
@@ -5,6 +5,7 @@ var requestLogger = require('./requestLogger');
 var packageJson = require('../../package.json');
 var fs = require('fs');
 var mime = require('mime');
+var { isValidFormat } = require('./smartsheetIntegrationSourceValidator');
 
 exports.create = function (requestorConfig) {
   var logger = requestorConfig.logger ? requestLogger.create(requestorConfig.logger) : requestLogger.empty;
@@ -60,9 +61,8 @@ exports.create = function (requestorConfig) {
     if (options.changeAgent) {
       headers['Smartsheet-Change-Agent'] = options.changeAgent;
     }
-    if (options.smartsheetIntegrationSource) {
-      headers['Smartsheet-Integration-Source'] = options.smartsheetIntegrationSource;
-    }
+    isValidFormat(options.smartsheetIntegrationSource);
+    headers['Smartsheet-Integration-Source'] = options.smartsheetIntegrationSource;
     if (options.customProperties) {
       for (const [key, value] of Object.entries(options.customProperties)) {
         headers[key] = value;

--- a/lib/utils/smartsheetIntegrationSourceType.js
+++ b/lib/utils/smartsheetIntegrationSourceType.js
@@ -8,7 +8,8 @@
 const SmartsheetIntegrationSourceType = {
   AI: 'AI',
   SCRIPT: 'SCRIPT', 
-  APPLICATION: 'APPLICATION'
+  APPLICATION: 'APPLICATION',
+  PERSONAL_ACCOUNT: 'PERSONAL_ACCOUNT'
 };
 
 module.exports = {

--- a/lib/utils/smartsheetIntegrationSourceType.js
+++ b/lib/utils/smartsheetIntegrationSourceType.js
@@ -1,0 +1,16 @@
+/**
+ * Smartsheet Integration Source Type Enum
+ * 
+ * Defines the valid integration source types that can be used
+ * in the Smartsheet-Integration-Source header.
+ */
+
+const SmartsheetIntegrationSourceType = {
+  AI: 'AI',
+  SCRIPT: 'SCRIPT', 
+  APPLICATION: 'APPLICATION'
+};
+
+module.exports = {
+  SmartsheetIntegrationSourceType
+};

--- a/lib/utils/smartsheetIntegrationSourceValidator.js
+++ b/lib/utils/smartsheetIntegrationSourceValidator.js
@@ -11,6 +11,8 @@
 
 const { SmartsheetIntegrationSourceType } = require('./smartsheetIntegrationSourceType');
 
+const documentationLink = "https://developers.smartsheet.com/api/smartsheet/guides/basics/http-and-rest#http-headers";
+
 /**
  * Validates a smartsheet integration source string
  * @param {string} inputValue - The integration source string to validate
@@ -22,9 +24,10 @@ function isValidFormat(inputValue) {
     throw new Error('Smartsheet integration source cannot be null');
   }
 
-  const parts = inputValue.split(',');
+  const parts = inputValue.split(',', -1); // -1 keeps empty slots
   if (parts.length !== 3) {
-    throw new Error('Invalid smartsheet integration source format');
+    throw new Error('Invalid smartsheet integration source format. ' +
+      'Expected format: \'TYPE,ORGANIZATION,INTEGRATOR. ' + documentationLink);
   }
 
   const integrationType = parts[0];
@@ -32,17 +35,14 @@ function isValidFormat(inputValue) {
 
   if (!isValidType(integrationType)) {
     const allowed = Object.values(SmartsheetIntegrationSourceType).join(', ');
-    throw new Error(
-      'Invalid smartsheet integration source format. ' +
-      'The integration type has to be one of the following: ' + allowed
-    );
+    throw new Error('Invalid smartsheet integration source format. ' +
+      'The integration type has to be one of the following: ' + allowed +
+      '. Invalid integration type: ' + integrationType + ' ' + documentationLink);
   }
 
   if (integratorName === '') {
-    throw new Error(
-      'Invalid smartsheet integration source format. ' +
-      'The integrator name cannot be empty.'
-    );
+    throw new Error('Invalid smartsheet integration source format. ' +
+      'The integrator name cannot be empty.');
   }
 
   return true;

--- a/lib/utils/smartsheetIntegrationSourceValidator.js
+++ b/lib/utils/smartsheetIntegrationSourceValidator.js
@@ -1,0 +1,69 @@
+/**
+ * Smartsheet Integration Source Validator
+ * 
+ * Validates smartsheet integration source strings in the format:
+ * type, organisation name, integrator name
+ * 
+ * - type: must be one of the enum values
+ * - organisation name: optional (can be empty)
+ * - integrator name: non-empty
+ */
+
+const { SmartsheetIntegrationSourceType } = require('./smartsheetIntegrationSourceType');
+
+/**
+ * Validates a smartsheet integration source string
+ * @param {string} inputValue - The integration source string to validate
+ * @returns {boolean} - True if valid, throws exception if invalid
+ * @throws {Error} - If validation fails
+ */
+function isValidFormat(inputValue) {
+  if (inputValue === null || inputValue === undefined) {
+    throw new Error('Smartsheet integration source cannot be null');
+  }
+
+  const parts = inputValue.split(',');
+  if (parts.length !== 3) {
+    throw new Error('Invalid smartsheet integration source format');
+  }
+
+  const integrationType = parts[0];
+  const integratorName = parts[2];
+
+  if (!isValidType(integrationType)) {
+    const allowed = Object.values(SmartsheetIntegrationSourceType).join(', ');
+    throw new Error(
+      'Invalid smartsheet integration source format. ' +
+      'The integration type has to be one of the following: ' + allowed
+    );
+  }
+
+  if (integratorName === '') {
+    throw new Error(
+      'Invalid smartsheet integration source format. ' +
+      'The integrator name cannot be empty.'
+    );
+  }
+
+  return true;
+}
+
+/**
+ * Checks if the integration type is valid
+ * @param {string} integrationTypeValue - The integration type to validate
+ * @returns {boolean} - True if valid, false otherwise
+ */
+function isValidType(integrationTypeValue) {
+  if (!integrationTypeValue || integrationTypeValue === '') {
+    return false;
+  }
+  
+  const upperValue = integrationTypeValue.toUpperCase();
+  return Object.values(SmartsheetIntegrationSourceType).includes(upperValue);
+}
+
+module.exports = {
+  SmartsheetIntegrationSourceType,
+  isValidFormat,
+  isValidType
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smartsheet",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smartsheet",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Smartsheet JavaScript client SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/test/functional/client_test.js
+++ b/test/functional/client_test.js
@@ -6,7 +6,10 @@ var smartsheet = null;
 describe('Client Unit Tests', function() {
   beforeEach(function() {
     client = require('../../');
-    smartsheet = client.createClient({accessToken:'1234'});
+    smartsheet = client.createClient({
+    accessToken:'1234',
+    smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+});
   });
 
   afterEach(function() {

--- a/test/functional/endpoints_test.js
+++ b/test/functional/endpoints_test.js
@@ -332,7 +332,13 @@ describe('Method Unit Tests', function () {
 
                     beforeEach(function () {
                         stub = sinon.stub(requestor, method.stub);
-                        client = smartsheet.createClient({accessToken: "token", requestor: requestor, userAgent: "user agent", baseUrl: "base url"});
+                        client = smartsheet.createClient({
+    accessToken: "token", 
+    requestor: requestor, 
+    userAgent: "user agent", 
+    baseUrl: "base url",
+    smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+});
                     });
 
                     afterEach(function () {

--- a/test/functional/sheets_test.js
+++ b/test/functional/sheets_test.js
@@ -9,7 +9,11 @@ describe('Client Unit Tests', function() {
     requestor = require('../../lib/utils/httpRequestor.js').create({});
     sinon.spy(requestor, 'get');
     var client = require('../..');
-    smartsheet = client.createClient({accessToken:'1234', requestor: requestor});
+    smartsheet = client.createClient({
+    accessToken:'1234', 
+    requestor: requestor,
+    smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+});
   });
 
   afterEach(function() {

--- a/test/functional/utils_test.js
+++ b/test/functional/utils_test.js
@@ -6,7 +6,10 @@ var fs = require('fs');
 const { smartSheetURIs } = require('../..');
 var axios = require('axios');
 
-var requestor = require('../../lib/utils/httpRequestor').create({request: axios});
+var requestor = require('../../lib/utils/httpRequestor').create({
+  request: axios,
+  smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+});
 
 var sample = {
   name : 'name'
@@ -14,12 +17,14 @@ var sample = {
 
 var sampleRequest = {
   url:'URL',
-  accessToken:'TOKEN'
+  accessToken:'TOKEN',
+  smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
 };
 
 var sampleRequestNoContentType = {
   accessToken: 'TOKEN',
-  body: sample
+  body: sample,
+  smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
 };
 
 var sampleRequestWithQueryParameters = {
@@ -29,7 +34,8 @@ var sampleRequestWithQueryParameters = {
   queryParameters: {
     parameter1:'',
     parameter2:''
-  }
+  },
+  smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
 };
 
 var EXPECTED_VERSION = packageJson.version;
@@ -119,92 +125,149 @@ describe('Utils Unit Tests', function() {
       });
 
       it('authorization header should have token', () => {
-        var headers = requestor.internal.buildHeaders({accessToken: 'token'});
+        var headers = requestor.internal.buildHeaders({
+        accessToken: 'token',
+        smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+      });
         headers.Authorization.should.equal('Bearer token');
       });
 
       it('accept header should equal ' + applicationJson, () => {
-        var headers = requestor.internal.buildHeaders({});
+        var headers = requestor.internal.buildHeaders({
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers.Accept.should.equal(applicationJson);
       });
 
       it('accept header should equal ' + newType, () => {
-        var headers = requestor.internal.buildHeaders({accept: newType});
+        var headers = requestor.internal.buildHeaders({
+          accept: newType,
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers.Accept.should.equal(newType);
       });
 
       it('content-type header should ' + applicationJson, () => {
-        var headers = requestor.internal.buildHeaders({contentType: applicationJson});
+        var headers = requestor.internal.buildHeaders({
+          contentType: applicationJson,
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['Content-Type'].should.equal(applicationJson);
       });
 
       it('content-type header should equal ' + newType, () => {
-        var headers = requestor.internal.buildHeaders({contentType: newType});
+        var headers = requestor.internal.buildHeaders({
+          contentType: newType,
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['Content-Type'].should.equal(newType);
       });
 
       it('Content-Type should equal ' + textCsv, () => {
-        var headers = requestor.internal.buildHeaders({fileName: 'test.csv'});
+        var headers = requestor.internal.buildHeaders({
+          fileName: 'test.csv',
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['Content-Type'].should.equal(textCsv);
       });
 
       it('Content-Type should equal ' + docType, () => {
-        var headers = requestor.internal.buildHeaders({fileName: 'test.docx'});
+        var headers = requestor.internal.buildHeaders({
+          fileName: 'test.docx',
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['Content-Type'].should.equal(docType);
       });
 
       it('Content-Type should equal ' + applicationJson, () => {
-        var headers = requestor.internal.buildHeaders({fileName: 'test'});
+        var headers = requestor.internal.buildHeaders({
+          fileName: 'test',
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['Content-Type'].should.equal(applicationJson);
       });
 
       it('Content-Disposition should equal filename', () => {
-        var headers = requestor.internal.buildHeaders({fileName: 'test'});
+        var headers = requestor.internal.buildHeaders({
+          fileName: 'test',
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['Content-Disposition'].should.equal('attachment; filename="test"');
       });
 
       it('Should set Content-Disposition to contentDisposition', () => {
-        var headers = requestor.internal.buildHeaders({contentDisposition: 'some content disposition'});
+        var headers = requestor.internal.buildHeaders({
+          contentDisposition: 'some content disposition',
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['Content-Disposition'].should.equal('some content disposition');
       });
 
       it('Should prefer contentDisposition to fileName', () => {
-        var headers = requestor.internal.buildHeaders({fileName: 'test', contentDisposition: 'something else'});
+        var headers = requestor.internal.buildHeaders({
+          fileName: 'test', 
+          contentDisposition: 'something else',
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['Content-Disposition'].should.equal('something else');
       });
 
       it('Should set Content-Length to fileSize', () => {
-        var headers = requestor.internal.buildHeaders({fileName: 'test',   fileSize: 123});
+        var headers = requestor.internal.buildHeaders({
+          fileName: 'test',   
+          fileSize: 123,
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['Content-Length'].should.equal(123);
       });
 
       it('Should set Content-Length from file size when path is specified', () => {
-        var headers = requestor.internal.buildHeaders({fileName: 'test',   path: "somePath"});
+        var headers = requestor.internal.buildHeaders({
+          fileName: 'test',   
+          path: "somePath",
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['Content-Length'].should.equal(234);
       });
 
       it('Should prefer path over fileSize for Content-Length', () => {
-        var headers = requestor.internal.buildHeaders({fileName: 'test',   path: "somePath", fileSize: 123});
+        var headers = requestor.internal.buildHeaders({
+          fileName: 'test',   
+          path: "somePath", 
+          fileSize: 123,
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['Content-Length'].should.equal(234);
       });
 
       it('Assume-User should equal URI encoded email', () => {
-        var headers = requestor.internal.buildHeaders({assumeUser: 'john.doe@smartsheet.com'});
+        var headers = requestor.internal.buildHeaders({
+          assumeUser: 'john.doe@smartsheet.com',
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['Assume-User'].should.equal('john.doe%40smartsheet.com');
       });
 
       it('Should set the user agent string based on the version', () => {
-        var headers = requestor.internal.buildHeaders({});
+        var headers = requestor.internal.buildHeaders({
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['User-Agent'].should.equal(`smartsheet-javascript-sdk/${packageJson.version}`);
       });
 
       it('Should used a passed in value for the user agent string', () => {
-        var headers = requestor.internal.buildHeaders({userAgent: 'someAgentString'});
+        var headers = requestor.internal.buildHeaders({
+          userAgent: 'someAgentString',
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['User-Agent'].should.equal(`smartsheet-javascript-sdk/${packageJson.version}/someAgentString`);
       });
 
       it('Custom properties should be allowed', () => {
-        var headers = requestor.internal.buildHeaders({customProperties: {custom1: 'value', custom2: 'value2'}});
+        var headers = requestor.internal.buildHeaders({
+          customProperties: {custom1: 'value', custom2: 'value2'},
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
         headers['custom1'].should.equal(`value`);
         headers['custom2'].should.equal(`value2`);
       });
@@ -215,7 +278,11 @@ describe('Utils Unit Tests', function() {
     describe('#Successful request', function() {
       var requestStub = null;
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: axios, handleResponse: () => ({ content: true })});
+        .create({
+          request: axios, 
+          handleResponse: () => ({ content: true }),
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
 
       beforeEach(() => {
         requestStub = sinon.stub(axios, 'get');
@@ -250,7 +317,11 @@ describe('Utils Unit Tests', function() {
     describe('#Error on request', function() {
       var requestStub = null;
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: axios, handleResponse: () => ({ content: true })});
+        .create({
+          request: axios, 
+          handleResponse: () => ({ content: true }),
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
       var mockBody;
 
       beforeEach(() => {
@@ -324,7 +395,11 @@ describe('Utils Unit Tests', function() {
       var requestStub = null;
       var handleResponseStub = sinon.stub();
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: axios, handleResponse: handleResponseStub});
+        .create({
+          request: axios, 
+          handleResponse: handleResponseStub,
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
       var sampleRequestForRetry = null;
 
       function givenGetReturnsError() {
@@ -396,7 +471,11 @@ describe('Utils Unit Tests', function() {
       var requestStub = null;
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: axios, handleResponse: () => ({content: true})});
+        .create({
+          request: axios, 
+          handleResponse: () => ({content: true}),
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
 
       beforeEach(() => {
         requestStub = sinon.stub(axios, 'post');
@@ -432,7 +511,11 @@ describe('Utils Unit Tests', function() {
       var mockBody = {error:true};
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: axios, handleResponse: () => ({content: true})});
+        .create({
+          request: axios, 
+          handleResponse: () => ({content: true}),
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
 
       beforeEach(() => {
         requestStub = sinon.stub(axios, 'post');
@@ -504,7 +587,11 @@ describe('Utils Unit Tests', function() {
       var handleResponseStub = sinon.stub();
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: axios, handleResponse: handleResponseStub});
+        .create({
+          request: axios, 
+          handleResponse: handleResponseStub,
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
 
       var sampleRequestForRetry;
 
@@ -578,7 +665,11 @@ describe('Utils Unit Tests', function() {
       var requestStub = null;
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: axios, handleResponse: () => ({content: true})});
+        .create({
+          request: axios, 
+          handleResponse: () => ({content: true}),
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
 
       beforeEach(() => {
         requestStub = sinon.stub(axios, 'put');
@@ -616,7 +707,11 @@ describe('Utils Unit Tests', function() {
       var mockBody = {error: true};
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: axios, handleResponse: () => ({content: true})});
+        .create({
+          request: axios, 
+          handleResponse: () => ({content: true}),
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
 
       beforeEach(() => {
         stub = sinon.stub(axios, 'put');
@@ -694,7 +789,11 @@ describe('Utils Unit Tests', function() {
       var handleResponseStub = sinon.stub();
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: axios, handleResponse: handleResponseStub});
+        .create({
+          request: axios, 
+          handleResponse: handleResponseStub,
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
 
       var sampleRequestForRetry = null;
 
@@ -768,7 +867,11 @@ describe('Utils Unit Tests', function() {
       var requestStub = null;
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: axios, handleResponse: () => ({content: true})});
+        .create({
+          request: axios, 
+          handleResponse: () => ({content: true}),
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
 
       beforeEach(() => {
         requestStub = sinon.stub(axios, 'delete');
@@ -807,7 +910,11 @@ describe('Utils Unit Tests', function() {
       var mockBody = {error: true};
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: axios, handleResponse: () => ({content: true})});
+        .create({
+          request: axios, 
+          handleResponse: () => ({content: true}),
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
 
       beforeEach(() => {
         requestStub = sinon.stub(axios, 'delete');
@@ -880,7 +987,11 @@ describe('Utils Unit Tests', function() {
       var handleResponseStub = sinon.stub();
 
       var stubbedRequestor = require('../../lib/utils/httpRequestor')
-        .create({request: axios, handleResponse: handleResponseStub});
+        .create({
+          request: axios, 
+          handleResponse: handleResponseStub,
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
 
       var sampleRequestForRetry;
 

--- a/test/mock-api/header_test.js
+++ b/test/mock-api/header_test.js
@@ -25,6 +25,24 @@ describe("Mock API SDK Tests", function() {
             },
             "changeAgent": "MyChangeAgent"
           }
+        },
+        {
+          "name": "Integration Source Header - Can Be Passed",
+          "method": client.sheets.createSheet,
+          "shouldError": false,
+          "options": {
+            "body": {
+              "name": "My new sheet",
+              "columns": [
+                {
+                  "title": "Col1",
+                  "primary": true,
+                  "type": "TEXT_NUMBER"
+                }
+              ]
+            },
+            "smartsheetIntegrationSource": "AI,MyCompany,MyGPT"
+          }
         }
       ];
 

--- a/test/mock-api/helpers.js
+++ b/test/mock-api/helpers.js
@@ -6,7 +6,11 @@ var sinon = require("sinon");
 var axios = require("axios");
 
 exports.setupClient = function() {
-    return smartsheet.createClient({accessToken:'1234', baseUrl: "http://localhost:8082/"});
+    return smartsheet.createClient({
+        accessToken:'1234', 
+        baseUrl: "http://localhost:8082/",
+        smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+    });
 };
 
 exports.defineMockApiTests = function(scenarios) {

--- a/test/unit/smartsheetIntegrationSourceHeaderValidation_test.js
+++ b/test/unit/smartsheetIntegrationSourceHeaderValidation_test.js
@@ -1,0 +1,119 @@
+const should = require('should');
+const { createClient } = require('../..');
+
+describe('SmartsheetIntegrationSource Header Validation', function() {
+  describe('Mandatory Header', function() {
+    it('should throw error when smartsheetIntegrationSource is missing from client creation', function() {
+      (function() {
+        createClient({
+          accessToken: 'test-token',
+          baseUrl: 'https://api.test.smartsheet.com/2.0/'
+        });
+      }).should.throw('Smartsheet integration source cannot be null');
+    });
+
+    it('should throw error when smartsheetIntegrationSource is null in client creation', function() {
+      (function() {
+        createClient({
+          accessToken: 'test-token',
+          baseUrl: 'https://api.test.smartsheet.com/2.0/',
+          smartsheetIntegrationSource: null
+        });
+      }).should.throw('Smartsheet integration source cannot be null');
+    });
+
+    it('should throw error when smartsheetIntegrationSource is undefined in client creation', function() {
+      (function() {
+        createClient({
+          accessToken: 'test-token',
+          baseUrl: 'https://api.test.smartsheet.com/2.0/',
+          smartsheetIntegrationSource: undefined
+        });
+      }).should.throw('Smartsheet integration source cannot be null');
+    });
+  });
+
+  describe('Header Format Validation', function() {
+    it('should throw error for invalid format - missing parts', function() {
+      (function() {
+        createClient({
+          accessToken: 'test-token',
+          baseUrl: 'https://api.test.smartsheet.com/2.0/',
+          smartsheetIntegrationSource: 'AI,MyOrg'
+        });
+      }).should.throw('Invalid smartsheet integration source format');
+    });
+
+    it('should throw error for invalid format - too many parts', function() {
+      (function() {
+        createClient({
+          accessToken: 'test-token',
+          baseUrl: 'https://api.test.smartsheet.com/2.0/',
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT,Extra'
+        });
+      }).should.throw('Invalid smartsheet integration source format');
+    });
+
+    it('should throw error for invalid type', function() {
+      (function() {
+        createClient({
+          accessToken: 'test-token',
+          baseUrl: 'https://api.test.smartsheet.com/2.0/',
+          smartsheetIntegrationSource: 'INVALID,MyOrg,MyGPT'
+        });
+      }).should.throw('Invalid smartsheet integration source format. The integration type has to be one of the following: AI, SCRIPT, APPLICATION');
+    });
+
+    it('should throw error for empty integrator name', function() {
+      (function() {
+        createClient({
+          accessToken: 'test-token',
+          baseUrl: 'https://api.test.smartsheet.com/2.0/',
+          smartsheetIntegrationSource: 'AI,MyOrg,'
+        });
+      }).should.throw('Invalid smartsheet integration source format. The integrator name cannot be empty.');
+    });
+  });
+
+  describe('Valid Headers', function() {
+    it('should accept valid AI integration source', function() {
+      (function() {
+        createClient({
+          accessToken: 'test-token',
+          baseUrl: 'https://api.test.smartsheet.com/2.0/',
+          smartsheetIntegrationSource: 'AI,MyOrg,MyGPT'
+        });
+      }).should.not.throw();
+    });
+
+    it('should accept valid SCRIPT integration source', function() {
+      (function() {
+        createClient({
+          accessToken: 'test-token',
+          baseUrl: 'https://api.test.smartsheet.com/2.0/',
+          smartsheetIntegrationSource: 'SCRIPT,MyOrg,MyGPT'
+        });
+      }).should.not.throw();
+    });
+
+    it('should accept valid APPLICATION integration source', function() {
+      (function() {
+        createClient({
+          accessToken: 'test-token',
+          baseUrl: 'https://api.test.smartsheet.com/2.0/',
+          smartsheetIntegrationSource: 'APPLICATION,MyOrg,MyGPT'
+        });
+      }).should.not.throw();
+    });
+
+    it('should accept empty organization name', function() {
+      (function() {
+        createClient({
+          accessToken: 'test-token',
+          baseUrl: 'https://api.test.smartsheet.com/2.0/',
+          smartsheetIntegrationSource: 'AI,,MyGPT'
+        });
+      }).should.not.throw();
+    });
+  });
+});

--- a/test/unit/smartsheetIntegrationSourceHeaderValidation_test.js
+++ b/test/unit/smartsheetIntegrationSourceHeaderValidation_test.js
@@ -41,7 +41,7 @@ describe('SmartsheetIntegrationSource Header Validation', function() {
           baseUrl: 'https://api.test.smartsheet.com/2.0/',
           smartsheetIntegrationSource: 'AI,MyOrg'
         });
-      }).should.throw('Invalid smartsheet integration source format');
+      }).should.throw('Invalid smartsheet integration source format. Expected format: \'TYPE,ORGANIZATION,INTEGRATOR. https://developers.smartsheet.com/api/smartsheet/guides/basics/http-and-rest#http-headers');
     });
 
     it('should throw error for invalid format - too many parts', function() {
@@ -51,7 +51,7 @@ describe('SmartsheetIntegrationSource Header Validation', function() {
           baseUrl: 'https://api.test.smartsheet.com/2.0/',
           smartsheetIntegrationSource: 'AI,MyOrg,MyGPT,Extra'
         });
-      }).should.throw('Invalid smartsheet integration source format');
+      }).should.throw('Invalid smartsheet integration source format. Expected format: \'TYPE,ORGANIZATION,INTEGRATOR. https://developers.smartsheet.com/api/smartsheet/guides/basics/http-and-rest#http-headers');
     });
 
     it('should throw error for invalid type', function() {
@@ -61,7 +61,7 @@ describe('SmartsheetIntegrationSource Header Validation', function() {
           baseUrl: 'https://api.test.smartsheet.com/2.0/',
           smartsheetIntegrationSource: 'INVALID,MyOrg,MyGPT'
         });
-      }).should.throw('Invalid smartsheet integration source format. The integration type has to be one of the following: AI, SCRIPT, APPLICATION');
+      }).should.throw('Invalid smartsheet integration source format. The integration type has to be one of the following: AI, SCRIPT, APPLICATION, PERSONAL_ACCOUNT. Invalid integration type: INVALID https://developers.smartsheet.com/api/smartsheet/guides/basics/http-and-rest#http-headers');
     });
 
     it('should throw error for empty integrator name', function() {
@@ -102,6 +102,16 @@ describe('SmartsheetIntegrationSource Header Validation', function() {
           accessToken: 'test-token',
           baseUrl: 'https://api.test.smartsheet.com/2.0/',
           smartsheetIntegrationSource: 'APPLICATION,MyOrg,MyGPT'
+        });
+      }).should.not.throw();
+    });
+
+    it('should accept valid PERSONAL_ACCOUNT integration source', function() {
+      (function() {
+        createClient({
+          accessToken: 'test-token',
+          baseUrl: 'https://api.test.smartsheet.com/2.0/',
+          smartsheetIntegrationSource: 'PERSONAL_ACCOUNT,MyOrg,MyGPT'
         });
       }).should.not.throw();
     });

--- a/test/unit/smartsheetIntegrationSourceValidator_test.js
+++ b/test/unit/smartsheetIntegrationSourceValidator_test.js
@@ -7,6 +7,7 @@ describe('SmartsheetIntegrationSourceValidator', function() {
       SmartsheetIntegrationSourceType.AI.should.equal('AI');
       SmartsheetIntegrationSourceType.SCRIPT.should.equal('SCRIPT');
       SmartsheetIntegrationSourceType.APPLICATION.should.equal('APPLICATION');
+      SmartsheetIntegrationSourceType.PERSONAL_ACCOUNT.should.equal('PERSONAL_ACCOUNT');
     });
   });
 
@@ -18,6 +19,8 @@ describe('SmartsheetIntegrationSourceValidator', function() {
       isValidType('script').should.be.true();
       isValidType('APPLICATION').should.be.true();
       isValidType('application').should.be.true();
+      isValidType('PERSONAL_ACCOUNT').should.be.true();
+      isValidType('personal_account').should.be.true();
     });
 
     it('should return false for invalid types', function() {
@@ -33,6 +36,7 @@ describe('SmartsheetIntegrationSourceValidator', function() {
       isValidFormat('AI,MyCompany,MyGPT').should.be.true();
       isValidFormat('SCRIPT,MyOrg,MyScript').should.be.true();
       isValidFormat('APPLICATION,Company,AppName').should.be.true();
+      isValidFormat('PERSONAL_ACCOUNT,MyAccount,MyTool').should.be.true();
       isValidFormat('AI,,MyGPT').should.be.true(); // Empty organization name is allowed
     });
 
@@ -51,17 +55,17 @@ describe('SmartsheetIntegrationSourceValidator', function() {
     it('should throw error for wrong number of parts', function() {
       (function() {
         isValidFormat('AI,MyCompany');
-      }).should.throw('Invalid smartsheet integration source format');
+      }).should.throw('Invalid smartsheet integration source format. Expected format: \'TYPE,ORGANIZATION,INTEGRATOR. https://developers.smartsheet.com/api/smartsheet/guides/basics/http-and-rest#http-headers');
 
       (function() {
         isValidFormat('AI,MyCompany,MyGPT,Extra');
-      }).should.throw('Invalid smartsheet integration source format');
+      }).should.throw('Invalid smartsheet integration source format. Expected format: \'TYPE,ORGANIZATION,INTEGRATOR. https://developers.smartsheet.com/api/smartsheet/guides/basics/http-and-rest#http-headers');
     });
 
     it('should throw error for invalid integration type', function() {
       (function() {
         isValidFormat('INVALID,MyCompany,MyGPT');
-      }).should.throw('Invalid smartsheet integration source format. The integration type has to be one of the following: AI, SCRIPT, APPLICATION');
+      }).should.throw('Invalid smartsheet integration source format. The integration type has to be one of the following: AI, SCRIPT, APPLICATION, PERSONAL_ACCOUNT. Invalid integration type: INVALID https://developers.smartsheet.com/api/smartsheet/guides/basics/http-and-rest#http-headers');
     });
 
     it('should throw error for empty integrator name', function() {

--- a/test/unit/smartsheetIntegrationSourceValidator_test.js
+++ b/test/unit/smartsheetIntegrationSourceValidator_test.js
@@ -1,0 +1,73 @@
+const should = require('should');
+const { SmartsheetIntegrationSourceType, isValidFormat, isValidType } = require('../../lib/utils/smartsheetIntegrationSourceValidator');
+
+describe('SmartsheetIntegrationSourceValidator', function() {
+  describe('SmartsheetIntegrationSourceType enum', function() {
+    it('should have the correct enum values', function() {
+      SmartsheetIntegrationSourceType.AI.should.equal('AI');
+      SmartsheetIntegrationSourceType.SCRIPT.should.equal('SCRIPT');
+      SmartsheetIntegrationSourceType.APPLICATION.should.equal('APPLICATION');
+    });
+  });
+
+  describe('isValidType', function() {
+    it('should return true for valid types', function() {
+      isValidType('AI').should.be.true();
+      isValidType('ai').should.be.true();
+      isValidType('SCRIPT').should.be.true();
+      isValidType('script').should.be.true();
+      isValidType('APPLICATION').should.be.true();
+      isValidType('application').should.be.true();
+    });
+
+    it('should return false for invalid types', function() {
+      isValidType('INVALID').should.be.false();
+      isValidType('').should.be.false();
+      isValidType(null).should.be.false();
+      isValidType(undefined).should.be.false();
+    });
+  });
+
+  describe('isValidFormat', function() {
+    it('should validate correct format', function() {
+      isValidFormat('AI,MyCompany,MyGPT').should.be.true();
+      isValidFormat('SCRIPT,MyOrg,MyScript').should.be.true();
+      isValidFormat('APPLICATION,Company,AppName').should.be.true();
+      isValidFormat('AI,,MyGPT').should.be.true(); // Empty organization name is allowed
+    });
+
+    it('should throw error for null input', function() {
+      (function() {
+        isValidFormat(null);
+      }).should.throw('Smartsheet integration source cannot be null');
+    });
+
+    it('should throw error for undefined input', function() {
+      (function() {
+        isValidFormat(undefined);
+      }).should.throw('Smartsheet integration source cannot be null');
+    });
+
+    it('should throw error for wrong number of parts', function() {
+      (function() {
+        isValidFormat('AI,MyCompany');
+      }).should.throw('Invalid smartsheet integration source format');
+
+      (function() {
+        isValidFormat('AI,MyCompany,MyGPT,Extra');
+      }).should.throw('Invalid smartsheet integration source format');
+    });
+
+    it('should throw error for invalid integration type', function() {
+      (function() {
+        isValidFormat('INVALID,MyCompany,MyGPT');
+      }).should.throw('Invalid smartsheet integration source format. The integration type has to be one of the following: AI, SCRIPT, APPLICATION');
+    });
+
+    it('should throw error for empty integrator name', function() {
+      (function() {
+        isValidFormat('AI,MyCompany,');
+      }).should.throw('Invalid smartsheet integration source format. The integrator name cannot be empty.');
+    });
+  });
+});


### PR DESCRIPTION
*** DO NOT MERGE ***


Added support for the Smartsheet-Integration-Source request header in httpRequestor.js. The header is used to distinguish between human-initiated API requests vs third-party initiated request such as AI connectors or IT Service Management. Smartsheet needs a way to breakdown Public API requests source in order to enhance services and innovate building new customer experiences with the uprising use of AI tools. AI connectors wishing to integrate with Smartsheet services can do so by providing the Smartsheet-Integration-Source header for their API calls.