### PR TITLE
PAPI-280: Seat Types endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 4.6.0 - 2025-09-25
 ### Added
   - Support for upgrade/downgrade endpoints
+  - Support for GET /users/{userId}/plans
+  - Support for DELETE /users/{userId}/plans/{planId}
 
 ## [4.5.0] - 2025-08-25
 ### Added

--- a/lib/users/index.js
+++ b/lib/users/index.js
@@ -50,6 +50,18 @@ exports.create = function (options) {
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
+  var listUserPlans = (getOptions, callback) => {
+    var urlOptions = { url: buildListUserPlansUrl(getOptions) };
+    var requestOptions = _.extend({}, optionsToSend, urlOptions, getOptions);
+    return requestor.get(requestOptions, callback);
+  };
+
+  var removeUserFromPlan = (deleteOptions, callback) => {
+    var urlOptions = { url: buildRemoveUserFromPlanUrl(deleteOptions) };
+    var requestOptions = _.extend({}, optionsToSend, urlOptions, deleteOptions);
+    return requestor.delete(requestOptions, callback);
+  };
+
   var buildProfileImageUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/profileimage';
 
   var buildDeactivateUserUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/deactivate';
@@ -61,6 +73,11 @@ exports.create = function (options) {
 
   var buildUserDowngradeUrl = (urlOptions) =>
     options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId + '/downgrade';
+
+  var buildRemoveUserFromPlanUrl = (urlOptions) =>
+    options.apiUrls.users + urlOptions.userId + '/plans/' + urlOptions.planId;
+
+  var buildListUserPlansUrl = (urlOptions) => options.apiUrls.users + urlOptions.userId + '/plans';
 
   var userObject = {
     getUser: listAllUsers,
@@ -75,6 +92,8 @@ exports.create = function (options) {
     addProfileImage: addProfileImage,
     upgradeUser: upgradeUser,
     downgradeUser: downgradeUser,
+    listUserPlans: listUserPlans,
+    removeUserFromPlan: removeUserFromPlan,
   };
 
   _.extend(userObject, alternateEmails.create(options));

--- a/test/functional/client_test.js
+++ b/test/functional/client_test.js
@@ -368,7 +368,7 @@ describe('Client Unit Tests', function() {
   describe('#users', function () {
     it('should have user object', function () {
       smartsheet.should.have.property('users');
-      Object.keys(smartsheet.users).should.be.length(17);
+      Object.keys(smartsheet.users).should.be.length(19);
     });
 
     it('should have get methods', function () {

--- a/test/functional/endpoints_test.js
+++ b/test/functional/endpoints_test.js
@@ -290,6 +290,8 @@ describe('Method Unit Tests', function () {
                 { name: 'reactivateUser', stub: 'post', options: {userId: 123}, expectedRequest: {url: "users/123/reactivate"}},
                 { name: 'upgradeUser', stub: 'post', options: {userId: 123, planId: 456, body: {seatType: 'MEMBER'}}, expectedRequest: {url: "users/123/plans/456/upgrade", body: {seatType: 'MEMBER'}}},
                 { name: 'downgradeUser', stub: 'post', options: {userId: 123, planId: 456, body: {seatType: 'VIEWER'}}, expectedRequest: {url: "users/123/plans/456/downgrade", body: {seatType: 'VIEWER'}}},
+                { name: 'listUserPlans', stub: 'get', options: { userId: 123 }, expectedRequest: { url: "users/123/plans" }},
+                { name: 'removeUserFromPlan', stub: 'delete', options: { userId: 123, planId: 456 }, expectedRequest: { url: "users/123/plans/456" }},
                 // alternate emails
                 { name: 'addAlternateEmail', stub: 'post', options: {userId: 123}, expectedRequest: {url: "users/123/alternateemails/"}},
                 { name: 'getAlternateEmail', stub: 'get', options: {userId: 123, alternateEmailId: 234}, expectedRequest: {url: "users/123/alternateemails/234"}},

--- a/test/mock-api/serialization_test.js
+++ b/test/mock-api/serialization_test.js
@@ -556,6 +556,23 @@ describe("Mock API SDK Tests", function() {
                     planId: 456,
                     body: { seatType: "VIEWER" }
                 }
+            },
+            {
+                name: "Serialization - ListUserPlans",
+                method: client.users.listUserPlans,
+                shouldError: false,
+                options: {
+                    userId: 123
+                }
+            },
+            {
+                name: "Serialization - RemoveUserFromPlan",
+                method: client.users.removeUserFromPlan,
+                shouldError: false,
+                options: {
+                    userId: 123,
+                    planId: 456
+                }
             }
         ];
 


### PR DESCRIPTION
## Summary

  This PR implements seat types functionality for the Smartsheet JavaScript SDK (PAPI-280).

  ## Changes Made

  - Added new user management functions in `lib/users/index.js` to support seat type operations
  - Bumps up test coverage
  - Updates the `CHANGELOG.md`