### PR TITLE
Remove trailing slashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - WiremMock integration tests for contract testing for GET /2.0/users/{userId}/plans and GET /2.0/users endpoints
 - WireMock integration tests for contract testing for POST /2.0/users/{userId}/plans/{planId}/upgrade and POST /2.0/users/{userId}/plans/{planId}/downgrade
+- Remove trailing slashes from routes
 ### Updated
 - listAllUsers url generation
 - Folder structure for the Users related WireMock tests
+- Update endpoint and sheet tests
 
 ## [4.7.0] - 2025-06-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.8.0] - Unreleased
+## [x.x.x] - Unreleased
 ### Added
 - WiremMock integration tests for contract testing for GET /2.0/users/{userId}/plans and GET /2.0/users endpoints
 - WireMock integration tests for contract testing for POST /2.0/users/{userId}/plans/{planId}/upgrade and POST /2.0/users/{userId}/plans/{planId}/downgrade

--- a/lib/contacts/index.ts
+++ b/lib/contacts/index.ts
@@ -13,13 +13,16 @@ import type { RequestOptions } from './../types/RequestOptions';
 export function createContacts(options: CreateOptions): ContactsApi {
   const requestor = options.requestor;
 
+  const baseUrl = options.apiUrls.contacts;
   const optionsToSend = {
-    url: options.apiUrls.contacts,
+    url: baseUrl,
     ...options.clientOptions,
   };
 
-  const getContact = (options: RequestOptions<GetContactOptions, GetContactBody>, callback: RequestCallback<Contact>) =>
-    requestor.get({ ...optionsToSend, ...options }, callback);
+  const getContact = (options: RequestOptions<GetContactOptions, GetContactBody>, callback: RequestCallback<Contact>) => {
+    const urlWithSlash = baseUrl + '/';
+    return requestor.get({ ...optionsToSend, url: urlWithSlash, ...options }, callback);
+  };
 
   const listContacts = (
     options: RequestOptions<ListContactsOptions, undefined>,

--- a/lib/contacts/index.ts
+++ b/lib/contacts/index.ts
@@ -19,7 +19,10 @@ export function createContacts(options: CreateOptions): ContactsApi {
     ...options.clientOptions,
   };
 
-  const getContact = (options: RequestOptions<GetContactOptions, GetContactBody>, callback: RequestCallback<Contact>) => {
+  const getContact = (
+    options: RequestOptions<GetContactOptions, GetContactBody>,
+    callback: RequestCallback<Contact>
+  ) => {
     const urlWithSlash = baseUrl + '/';
     return requestor.get({ ...optionsToSend, url: urlWithSlash, ...options }, callback);
   };

--- a/lib/favorites/index.js
+++ b/lib/favorites/index.js
@@ -53,7 +53,9 @@ exports.create = (options) => {
     }
 
     var urlOptions = {
-      url: options.apiUrls.favorites + deleteOptions.type + '/' + (deleteOptions.id || deleteOptions.objectId || ''),
+      url: deleteOptions.favoriteId ? 
+      options.apiUrls.favorites + '/' + deleteOptions.type + '/' + deleteOptions.favoriteId : 
+      options.apiUrls.favorites + '/' + deleteOptions.type
     };
     return requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);
   };

--- a/lib/favorites/index.js
+++ b/lib/favorites/index.js
@@ -53,8 +53,8 @@ exports.create = (options) => {
     }
 
     var urlOptions = {
-      url: deleteOptions.favoriteId
-        ? options.apiUrls.favorites + '/' + deleteOptions.type + '/' + deleteOptions.favoriteId
+      url: deleteOptions.objectId
+        ? options.apiUrls.favorites + '/' + deleteOptions.type + '/' + deleteOptions.objectId
         : options.apiUrls.favorites + '/' + deleteOptions.type,
     };
     return requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);

--- a/lib/favorites/index.js
+++ b/lib/favorites/index.js
@@ -53,9 +53,9 @@ exports.create = (options) => {
     }
 
     var urlOptions = {
-      url: deleteOptions.favoriteId ? 
-      options.apiUrls.favorites + '/' + deleteOptions.type + '/' + deleteOptions.favoriteId : 
-      options.apiUrls.favorites + '/' + deleteOptions.type
+      url: deleteOptions.favoriteId
+        ? options.apiUrls.favorites + '/' + deleteOptions.type + '/' + deleteOptions.favoriteId
+        : options.apiUrls.favorites + '/' + deleteOptions.type,
     };
     return requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);
   };

--- a/lib/folders/index.js
+++ b/lib/folders/index.js
@@ -27,22 +27,27 @@ exports.create = function (options) {
   };
 
   var createChildFolder = (postOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.folders + postOptions.folderId + '/folders' };
+    var urlOptions = { url: options.apiUrls.folders + '/' + postOptions.folderId + '/folders' };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
-  var updateFolder = (putOptions, callback) => requestor.put(_.extend({}, optionsToSend, putOptions), callback);
+  var updateFolder = (putOptions, callback) => {
+    var urlOptions = { url: options.apiUrls.folders + '/' + putOptions.folderId };
+    requestor.put(_.extend({}, optionsToSend, urlOptions, putOptions), callback);
+  }
 
-  var deleteFolder = (deleteOptions, callback) =>
-    requestor.delete(_.extend({}, optionsToSend, deleteOptions), callback);
+  var deleteFolder = (deleteOptions, callback) => {
+    var urlOptions = { url: options.apiUrls.folders + '/' + deleteOptions.folderId };
+    requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);
+  };
 
   var copyFolder = (postOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.folders + postOptions.folderId + '/copy' };
+    var urlOptions = { url: options.apiUrls.folders + '/' + postOptions.folderId + '/copy' };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
   var moveFolder = (postOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.folders + postOptions.folderId + '/move' };
+    var urlOptions = { url: options.apiUrls.folders + '/' + postOptions.folderId + '/move' };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
@@ -55,7 +60,7 @@ exports.create = function (options) {
    * @param {Function} callback - Callback function
    */
   var getFolderMetadata = (getOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.folders + getOptions.folderId + '/metadata' };
+    var urlOptions = { url: options.apiUrls.folders + '/' + getOptions.folderId + '/metadata' };
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 
@@ -71,7 +76,7 @@ exports.create = function (options) {
    * @param {Function} callback - Callback function
    */
   var getFolderChildren = (getOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.folders + getOptions.folderId + '/children' };
+    var urlOptions = { url: options.apiUrls.folders + '/' + getOptions.folderId + '/children' };
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 

--- a/lib/folders/index.js
+++ b/lib/folders/index.js
@@ -34,7 +34,7 @@ exports.create = function (options) {
   var updateFolder = (putOptions, callback) => {
     var urlOptions = { url: options.apiUrls.folders + '/' + putOptions.folderId };
     requestor.put(_.extend({}, optionsToSend, urlOptions, putOptions), callback);
-  }
+  };
 
   var deleteFolder = (deleteOptions, callback) => {
     var urlOptions = { url: options.apiUrls.folders + '/' + deleteOptions.folderId };

--- a/lib/folders/index.js
+++ b/lib/folders/index.js
@@ -22,7 +22,7 @@ exports.create = function (options) {
    */
   var listChildFolders = (getOptions, callback) => {
     console.warn('DEPRECATED: Folders.listChildFolders is deprecated. Use getFolderChildren instead.');
-    var urlOptions = { url: options.apiUrls.folders + getOptions.folderId + '/folders' };
+    var urlOptions = { url: options.apiUrls.folders + '/' + getOptions.folderId + '/folders' };
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 

--- a/lib/groups/index.js
+++ b/lib/groups/index.js
@@ -20,12 +20,12 @@ exports.create = function (options) {
   var updateGroup = (putOptions, callback) => {
     var urlOptions = { url: options.apiUrls.groups + '/' + putOptions.groupId };
     requestor.put(_.extend({}, optionsToSend, urlOptions, putOptions), callback);
-  }
+  };
 
   var deleteGroup = (deleteOptions, callback) => {
     var urlOptions = { url: options.apiUrls.groups + '/' + deleteOptions.groupId };
     requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);
-  }
+  };
 
   var removeGroupMember = (deleteOptions, callback) => {
     var urlOptions = { url: options.apiUrls.groups + '/' + deleteOptions.groupId + '/members/' + deleteOptions.userId };

--- a/lib/groups/index.js
+++ b/lib/groups/index.js
@@ -13,16 +13,22 @@ exports.create = function (options) {
   var createGroup = (postOptions, callback) => requestor.post(_.extend({}, optionsToSend, postOptions), callback);
 
   var addGroupMembers = (postOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.groups + postOptions.groupId + '/members/' };
+    var urlOptions = { url: options.apiUrls.groups + '/' + postOptions.groupId + '/members' };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
-  var updateGroup = (putOptions, callback) => requestor.put(_.extend({}, optionsToSend, putOptions), callback);
+  var updateGroup = (putOptions, callback) => {
+    var urlOptions = { url: options.apiUrls.groups + '/' + putOptions.groupId };
+    requestor.put(_.extend({}, optionsToSend, urlOptions, putOptions), callback);
+  }
 
-  var deleteGroup = (deleteOptions, callback) => requestor.delete(_.extend({}, optionsToSend, deleteOptions), callback);
+  var deleteGroup = (deleteOptions, callback) => {
+    var urlOptions = { url: options.apiUrls.groups + '/' + deleteOptions.groupId };
+    requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);
+  }
 
   var removeGroupMember = (deleteOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.groups + deleteOptions.groupId + '/members/' + deleteOptions.userId };
+    var urlOptions = { url: options.apiUrls.groups + '/' + deleteOptions.groupId + '/members/' + deleteOptions.userId };
     return requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);
   };
 

--- a/lib/home/index.js
+++ b/lib/home/index.js
@@ -21,7 +21,7 @@ exports.create = function (options) {
    */
   var listFolders = (getOptions, callback) => {
     console.warn('DEPRECATED: Home.listFolders is deprecated.');
-    return listContents(_.extend({ url: options.apiUrls.home + 'folders' }, getOptions), callback);
+    return listContents(_.extend({ url: options.apiUrls.home + '/' + 'folders' }, getOptions), callback);
   };
 
   /**
@@ -29,7 +29,7 @@ exports.create = function (options) {
    */
   var createFolder = (postOptions, callback) => {
     console.warn('DEPRECATED: Home.createFolder is deprecated.');
-    var urlOptions = { url: options.apiUrls.home + 'folders' };
+    var urlOptions = { url: options.apiUrls.home + '/' + 'folders' };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 

--- a/lib/reports/index.js
+++ b/lib/reports/index.js
@@ -12,31 +12,34 @@ exports.create = function (options) {
   _.extend(optionsToSend, options.clientOptions);
 
   var getReport = (getOptions, callback) => {
-    return requestor.get(_.extend({}, optionsToSend, getOptions), callback);
+    var urlOptions = { url: options.apiUrls.reports + '/' + getOptions.reportId };
+    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 
   var sendReportViaEmail = (postOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.reports + postOptions.reportId + '/emails' };
+    var urlOptions = { url: options.apiUrls.reports + '/' + postOptions.reportId + '/emails' };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
   var getReportAsExcel = (getOptions, callback) => {
     var acceptOptions = { accept: constants.acceptHeaders.vndMsExcel, encoding: null };
-    return requestor.get(_.extend({}, optionsToSend, acceptOptions, getOptions), callback);
+    var urlOptions = { url: options.apiUrls.reports + '/' + getOptions.reportId };
+    return requestor.get(_.extend({}, optionsToSend, acceptOptions, urlOptions, getOptions), callback);
   };
 
   var getReportAsCSV = (getOptions, callback) => {
     var acceptOptions = { accept: constants.acceptHeaders.textCsv };
-    return requestor.get(_.extend({}, optionsToSend, acceptOptions, getOptions), callback);
+    var urlOptions = { url: options.apiUrls.reports + '/' + getOptions.reportId };
+    return requestor.get(_.extend({}, optionsToSend, acceptOptions, urlOptions, getOptions), callback);
   };
 
   var getReportPublishStatus = (getOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.reports + getOptions.reportId + '/publish' };
+    var urlOptions = { url: options.apiUrls.reports + '/' + getOptions.reportId + '/publish' };
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 
   var setReportPublishStatus = (putOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.reports + putOptions.reportId + '/publish' };
+    var urlOptions = { url: options.apiUrls.reports + '/' + putOptions.reportId + '/publish' };
     return requestor.put(_.extend({}, optionsToSend, urlOptions, putOptions), callback);
   };
 

--- a/lib/reports/index.js
+++ b/lib/reports/index.js
@@ -13,7 +13,7 @@ exports.create = function (options) {
 
   var getReport = (getOptions, callback) => {
     let url = options.apiUrls.reports;
-    if (getOptions.reportId !== undefined) {
+    if (getOptions?.reportId) {
       url += '/' + getOptions.reportId;
     }
     var urlOptions = { url };

--- a/lib/reports/index.js
+++ b/lib/reports/index.js
@@ -12,7 +12,11 @@ exports.create = function (options) {
   _.extend(optionsToSend, options.clientOptions);
 
   var getReport = (getOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.reports + '/' + getOptions.reportId };
+    let url = options.apiUrls.reports;
+    if (getOptions.reportId !== undefined) {
+      url += '/' + getOptions.reportId;
+    }
+    var urlOptions = { url };
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 

--- a/lib/search/index.ts
+++ b/lib/search/index.ts
@@ -1,4 +1,5 @@
 import type { CreateOptions, RequestCallback } from '../types';
+import { apiUrls } from '../utils/apis';
 import type { SearchAllOptions, SearchApi, SearchResponse, SearchSheetOptions } from './types';
 
 export const createSearch = (options: CreateOptions): SearchApi => {
@@ -29,9 +30,10 @@ export const createSearch = (options: CreateOptions): SearchApi => {
       ...getOptions,
       queryParameters: {
         query: getOptions.query,
-        sheetId: getOptions.sheetId,
       },
     };
+
+    options.url = apiUrls.search + '/sheets/' + getOptions.sheetId;
 
     return requestor.get(options, callback);
   };

--- a/lib/share/share.js
+++ b/lib/share/share.js
@@ -60,10 +60,11 @@ module.exports = (url) => ({
     };
 
     var buildUrl = (urlOptions) =>
-    url + '/' +
-    (urlOptions.sheetId || urlOptions.workspaceId || urlOptions.reportId || urlOptions.sightId) +
-    '/shares' +
-    ((urlOptions.shareId !== undefined) ? ('/' + urlOptions.shareId) : '');
+      url +
+      '/' +
+      (urlOptions.sheetId || urlOptions.workspaceId || urlOptions.reportId || urlOptions.sightId) +
+      '/shares' +
+      (urlOptions.shareId !== undefined ? '/' + urlOptions.shareId : '');
 
     return {
       /**

--- a/lib/share/share.js
+++ b/lib/share/share.js
@@ -60,10 +60,10 @@ module.exports = (url) => ({
     };
 
     var buildUrl = (urlOptions) =>
-      url +
-      (urlOptions.sheetId || urlOptions.workspaceId || urlOptions.reportId || urlOptions.sightId) +
-      '/shares/' +
-      (urlOptions.shareId || '');
+    url + '/' +
+    (urlOptions.sheetId || urlOptions.workspaceId || urlOptions.reportId || urlOptions.sightId) +
+    '/shares' +
+    ((urlOptions.shareId !== undefined) ? ('/' + urlOptions.shareId) : '');
 
     return {
       /**

--- a/lib/sheets/attachments.js
+++ b/lib/sheets/attachments.js
@@ -40,8 +40,13 @@ exports.create = function (options) {
     return requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);
   };
 
-  var buildUrl = (urlOptions) =>
-    options.apiUrls.sheets + urlOptions.sheetId + '/attachments/' + (urlOptions.attachmentId || '');
+  var buildUrl = (urlOptions) => {
+    let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/attachments';
+    if (urlOptions.attachmentId !== undefined) {
+      url += '/' + urlOptions.attachmentId;
+    }
+    return url;
+  };
 
   return {
     getAttachment: listAttachments,

--- a/lib/sheets/automationrules.js
+++ b/lib/sheets/automationrules.js
@@ -25,8 +25,13 @@ exports.create = function (options) {
     return requestor.put(_.extend({}, optionsToSend, urlOptions, putOptions), callback);
   };
 
-  var buildUrl = (urlOptions) =>
-    options.apiUrls.sheets + urlOptions.sheetId + '/automationrules/' + (urlOptions.automationRuleId || '');
+    var buildUrl = (urlOptions) => {
+      let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/automationrules';
+      if (urlOptions.automationRuleId !== undefined) {
+        url += '/' + urlOptions.automationRuleId;
+      }
+      return url;
+    };
 
   return {
     deleteAutomationRule: deleteAutomationRule,

--- a/lib/sheets/automationrules.js
+++ b/lib/sheets/automationrules.js
@@ -25,13 +25,13 @@ exports.create = function (options) {
     return requestor.put(_.extend({}, optionsToSend, urlOptions, putOptions), callback);
   };
 
-    var buildUrl = (urlOptions) => {
-      let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/automationrules';
-      if (urlOptions.automationRuleId !== undefined) {
-        url += '/' + urlOptions.automationRuleId;
-      }
-      return url;
-    };
+  var buildUrl = (urlOptions) => {
+    let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/automationrules';
+    if (urlOptions.automationRuleId !== undefined) {
+      url += '/' + urlOptions.automationRuleId;
+    }
+    return url;
+  };
 
   return {
     deleteAutomationRule: deleteAutomationRule,

--- a/lib/sheets/columns.js
+++ b/lib/sheets/columns.js
@@ -25,13 +25,13 @@ exports.create = function (options) {
     return requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);
   };
 
-    var buildUrl = (urlOptions) => {
-      let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/columns';
-      if (urlOptions.columnId !== undefined) {
-        url += '/' + urlOptions.columnId;
-      }
-      return url;
-    };
+  var buildUrl = (urlOptions) => {
+    let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/columns';
+    if (urlOptions.columnId !== undefined) {
+      url += '/' + urlOptions.columnId;
+    }
+    return url;
+  };
 
   return {
     getColumns: getColumns,

--- a/lib/sheets/columns.js
+++ b/lib/sheets/columns.js
@@ -25,8 +25,13 @@ exports.create = function (options) {
     return requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);
   };
 
-  var buildUrl = (urlOptions) =>
-    options.apiUrls.sheets + urlOptions.sheetId + '/columns/' + (urlOptions.columnId || '');
+    var buildUrl = (urlOptions) => {
+      let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/columns';
+      if (urlOptions.columnId !== undefined) {
+        url += '/' + urlOptions.columnId;
+      }
+      return url;
+    };
 
   return {
     getColumns: getColumns,

--- a/lib/sheets/comments.js
+++ b/lib/sheets/comments.js
@@ -31,7 +31,7 @@ exports.create = function (options) {
   };
 
   var buildUrl = (urlOptions) =>
-    options.apiUrls.sheets + urlOptions.sheetId + '/comments/' + (urlOptions.commentId || '');
+    options.apiUrls.sheets + '/' + urlOptions.sheetId + '/comments/' + (urlOptions.commentId || '');
 
   return {
     getComment: getComment,

--- a/lib/sheets/create.js
+++ b/lib/sheets/create.js
@@ -33,7 +33,7 @@ exports.create = function (options) {
   };
 
   var copySheet = (postOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.sheets + postOptions.sheetId + '/copy' };
+    var urlOptions = { url: options.apiUrls.sheets + '/' + postOptions.sheetId + '/copy' };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
@@ -47,21 +47,21 @@ exports.create = function (options) {
   };
 
   var _importXlsxAndReplaceSheet = (postOptions, callback) => {
-    var baseUrl = options.apiUrls.sheets + postOptions.sheetId + '/';
+    var baseUrl = options.apiUrls.sheets + '/' + postOptions.sheetId + '/';
     return importSheet(postOptions, callback, headers.vndOpenXml, baseUrl);
   };
 
   var _importCsvAndReplaceSheet = (postOptions, callback) => {
-    var baseUrl = options.apiUrls.sheets + postOptions.sheetId + '/';
+    var baseUrl = options.apiUrls.sheets + '/' + postOptions.sheetId + '/';
     return importSheet(postOptions, callback, headers.textCsv, baseUrl);
   };
 
   var importXlsxSheet = (postOptions, callback) => {
-    return importSheet(postOptions, callback, headers.vndOpenXml, options.apiUrls.sheets);
+    return importSheet(postOptions, callback, headers.vndOpenXml, options.apiUrls.sheets + '/');
   };
 
   var importCsvSheet = (postOptions, callback) => {
-    return importSheet(postOptions, callback, headers.textCsv, options.apiUrls.sheets);
+    return importSheet(postOptions, callback, headers.textCsv, options.apiUrls.sheets + '/');
   };
 
   var importXlsxSheetIntoFolder = (postOptions, callback) => {
@@ -81,11 +81,11 @@ exports.create = function (options) {
   };
 
   var buildFolderUrl = (requestOptions) => {
-    return options.apiUrls.folders + requestOptions.folderId + '/sheets';
+    return options.apiUrls.folders + '/' + requestOptions.folderId + '/sheets';
   };
 
   var buildWorkspaceUrl = (requestOptions) => {
-    return options.apiUrls.workspaces + requestOptions.workspaceId + '/sheets';
+    return options.apiUrls.workspaces + '/' + requestOptions.workspaceId + '/sheets';
   };
 
   return {

--- a/lib/sheets/crosssheetreferences.js
+++ b/lib/sheets/crosssheetreferences.js
@@ -11,7 +11,7 @@ exports.create = function (options) {
   };
 
   var getCrossSheetReference = (getOptions, callback) => {
-    var urlOptions = { url: buildUrlBase(getOptions) + getOptions.crossSheetReferenceId };
+    var urlOptions = { url: buildUrlBase(getOptions) + '/' + getOptions.crossSheetReferenceId };
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 
@@ -20,7 +20,7 @@ exports.create = function (options) {
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 
-  var buildUrlBase = (urlOptions) => options.apiUrls.sheets + urlOptions.sheetId + '/crosssheetreferences/';
+  var buildUrlBase = (urlOptions) => options.apiUrls.sheets + '/' + urlOptions.sheetId + '/crosssheetreferences';
 
   return {
     createCrossSheetReference: createCrossSheetReference,

--- a/lib/sheets/discussions.js
+++ b/lib/sheets/discussions.js
@@ -30,13 +30,13 @@ exports.create = function (options) {
     return requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);
   };
 
-    var buildUrl = (urlOptions) => {
-      let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/discussions';
-      if (urlOptions.discussionId !== undefined) {
-        url += '/' + urlOptions.discussionId;
-      }
-      return url;
-    };
+  var buildUrl = (urlOptions) => {
+    let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/discussions';
+    if (urlOptions.discussionId !== undefined) {
+      url += '/' + urlOptions.discussionId;
+    }
+    return url;
+  };
 
   return {
     getDiscussions: getDiscussions,

--- a/lib/sheets/discussions.js
+++ b/lib/sheets/discussions.js
@@ -30,8 +30,13 @@ exports.create = function (options) {
     return requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);
   };
 
-  var buildUrl = (urlOptions) =>
-    options.apiUrls.sheets + urlOptions.sheetId + '/discussions/' + (urlOptions.discussionId || '');
+    var buildUrl = (urlOptions) => {
+      let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/discussions';
+      if (urlOptions.discussionId !== undefined) {
+        url += '/' + urlOptions.discussionId;
+      }
+      return url;
+    };
 
   return {
     getDiscussions: getDiscussions,

--- a/lib/sheets/get.js
+++ b/lib/sheets/get.js
@@ -21,7 +21,7 @@ exports.create = function (options) {
     listSheets(_.extend({}, getOptions, { accept: headers.vndMsExcel, encoding: null }), callback);
 
   var getSheetVersion = (getOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.sheets + getOptions.sheetId + '/version' };
+    var urlOptions = { url: options.apiUrls.sheets + '/' + getOptions.sheetId + '/version' };
     return listSheets(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 

--- a/lib/sheets/index.js
+++ b/lib/sheets/index.js
@@ -24,37 +24,37 @@ exports.create = function (options) {
   _.extend(optionsToSend, options.clientOptions);
 
   var updateSheet = (putOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.sheets };
+    var urlOptions = { url: options.apiUrls.sheets + '/' + putOptions.sheetId };
     return requestor.put(_.extend({}, optionsToSend, urlOptions, putOptions), callback);
   };
 
   var deleteSheet = (deleteOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.sheets };
+    var urlOptions = { url: options.apiUrls.sheets + '/' + deleteOptions.sheetId };
     return requestor.delete(_.extend({}, optionsToSend, urlOptions, deleteOptions), callback);
   };
 
   var sendSheetViaEmail = (postOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.sheets + postOptions.sheetId + '/emails' };
+    var urlOptions = { url: options.apiUrls.sheets + '/' + postOptions.sheetId + '/emails' };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
   var moveSheet = (postOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.sheets + postOptions.sheetId + '/move' };
+    var urlOptions = { url: options.apiUrls.sheets + '/' + postOptions.sheetId + '/move' };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
   var getPublishStatus = (getOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.sheets + getOptions.sheetId + '/publish' };
+    var urlOptions = { url: options.apiUrls.sheets + '/' + getOptions.sheetId + '/publish' };
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 
   var setPublishStatus = (putOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.sheets + putOptions.sheetId + '/publish' };
+    var urlOptions = { url: options.apiUrls.sheets + '/' + putOptions.sheetId + '/publish' };
     return requestor.put(_.extend({}, optionsToSend, urlOptions, putOptions), callback);
   };
 
   var sortRowsInSheet = (postOptions, callback) => {
-    var urlOptions = { url: options.apiUrls.sheets + postOptions.sheetId + '/sort' };
+    var urlOptions = { url: options.apiUrls.sheets + '/' + postOptions.sheetId + '/sort' };
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 

--- a/lib/sheets/rows.js
+++ b/lib/sheets/rows.js
@@ -88,7 +88,7 @@ exports.create = function (options) {
 
   var buildUrlWithRowId = (urlOptions) => buildUrl(urlOptions) + '/' + urlOptions.rowId;
 
-  var buildUrl = (urlOptions) => options.apiUrls.sheets + urlOptions.sheetId + '/rows';
+  var buildUrl = (urlOptions) => options.apiUrls.sheets + '/' + urlOptions.sheetId + '/rows';
 
   return {
     getRow: getRow,

--- a/lib/sheets/sentupdaterequests.js
+++ b/lib/sheets/sentupdaterequests.js
@@ -20,13 +20,13 @@ exports.create = function (options) {
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 
-    var buildUrl = (urlOptions) => {
-      let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/sentupdaterequests';
-      if (urlOptions.sentUpdateRequestId !== undefined) {
-        url += '/' + urlOptions.sentUpdateRequestId;
-      }
-      return url;
-    };
+  var buildUrl = (urlOptions) => {
+    let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/sentupdaterequests';
+    if (urlOptions.sentUpdateRequestId !== undefined) {
+      url += '/' + urlOptions.sentUpdateRequestId;
+    }
+    return url;
+  };
 
   return {
     deleteSentUpdateRequest: deleteSentUpdateRequest,

--- a/lib/sheets/sentupdaterequests.js
+++ b/lib/sheets/sentupdaterequests.js
@@ -20,8 +20,13 @@ exports.create = function (options) {
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 
-  var buildUrl = (urlOptions) =>
-    options.apiUrls.sheets + urlOptions.sheetId + '/sentupdaterequests/' + (urlOptions.sentUpdateRequestId || '');
+    var buildUrl = (urlOptions) => {
+      let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/sentupdaterequests';
+      if (urlOptions.sentUpdateRequestId !== undefined) {
+        url += '/' + urlOptions.sentUpdateRequestId;
+      }
+      return url;
+    };
 
   return {
     deleteSentUpdateRequest: deleteSentUpdateRequest,

--- a/lib/sheets/sheetsummaries.js
+++ b/lib/sheets/sheetsummaries.js
@@ -35,7 +35,7 @@ exports.create = function (options) {
     return requestor.postFile(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
-  var buildSummaryUrl = (urlOptions) => options.apiUrls.sheets + urlOptions.sheetId + '/summary';
+  var buildSummaryUrl = (urlOptions) => options.apiUrls.sheets + '/' + urlOptions.sheetId + '/summary';
 
   var buildFieldsUrl = (urlOptions) => buildSummaryUrl(urlOptions) + '/fields';
 

--- a/lib/sheets/updaterequests.js
+++ b/lib/sheets/updaterequests.js
@@ -30,8 +30,13 @@ exports.create = function (options) {
     return requestor.put(_.extend({}, optionsToSend, urlOptions, putOptions), callback);
   };
 
-  var buildUrl = (urlOptions) =>
-    options.apiUrls.sheets + urlOptions.sheetId + '/updaterequests/' + (urlOptions.updateRequestId || '');
+    var buildUrl = (urlOptions) => {
+      let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/updaterequests';
+      if (urlOptions.updateRequestId !== undefined) {
+        url += '/' + urlOptions.updateRequestId;
+      }
+      return url;
+    };
 
   return {
     createUpdateRequest: createUpdateRequest,

--- a/lib/sheets/updaterequests.js
+++ b/lib/sheets/updaterequests.js
@@ -30,13 +30,13 @@ exports.create = function (options) {
     return requestor.put(_.extend({}, optionsToSend, urlOptions, putOptions), callback);
   };
 
-    var buildUrl = (urlOptions) => {
-      let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/updaterequests';
-      if (urlOptions.updateRequestId !== undefined) {
-        url += '/' + urlOptions.updateRequestId;
-      }
-      return url;
-    };
+  var buildUrl = (urlOptions) => {
+    let url = options.apiUrls.sheets + '/' + urlOptions.sheetId + '/updaterequests';
+    if (urlOptions.updateRequestId !== undefined) {
+      url += '/' + urlOptions.updateRequestId;
+    }
+    return url;
+  };
 
   return {
     createUpdateRequest: createUpdateRequest,

--- a/lib/sights/index.ts
+++ b/lib/sights/index.ts
@@ -25,7 +25,7 @@ export const createSights = (options: CreateOptions): SightsApi => {
   const getSight: GetSight = (getOptions, callback) => {
     const requestOptions = {
       ...optionsToSend,
-      url: `${options.apiUrls.sights}${getOptions.sightId}`,
+      url: `${options.apiUrls.sights}/${getOptions.sightId}`,
       ...getOptions,
     };
     return requestor.get(requestOptions, callback);
@@ -43,7 +43,7 @@ export const createSights = (options: CreateOptions): SightsApi => {
   const deleteSight: DeleteSight = (deleteOptions, callback) => {
     const requestOptions = {
       ...optionsToSend,
-      url: `${options.apiUrls.sights}${deleteOptions.sightId}`,
+      url: `${options.apiUrls.sights}/${deleteOptions.sightId}`,
       ...deleteOptions,
     };
     return requestor.delete(requestOptions, callback);
@@ -52,7 +52,7 @@ export const createSights = (options: CreateOptions): SightsApi => {
   const updateSight: UpdateSight = (putOptions, callback) => {
     const requestOptions = {
       ...optionsToSend,
-      url: `${options.apiUrls.sights}${putOptions.sightId}`,
+      url: `${options.apiUrls.sights}/${putOptions.sightId}`,
       ...putOptions,
     };
     return requestor.put(requestOptions, callback);
@@ -61,7 +61,7 @@ export const createSights = (options: CreateOptions): SightsApi => {
   const copySight: CopySight = (postOptions, callback) => {
     const requestOptions = {
       ...optionsToSend,
-      url: `${options.apiUrls.sights}${postOptions.sightId}/copy`,
+      url: `${options.apiUrls.sights}/${postOptions.sightId}/copy`,
       ...postOptions,
     };
     return requestor.post(requestOptions, callback);
@@ -70,7 +70,7 @@ export const createSights = (options: CreateOptions): SightsApi => {
   const moveSight: MoveSight = (postOptions, callback) => {
     const requestOptions = {
       ...optionsToSend,
-      url: `${options.apiUrls.sights}${postOptions.sightId}/move`,
+      url: `${options.apiUrls.sights}/${postOptions.sightId}/move`,
       ...postOptions,
     };
     return requestor.post(requestOptions, callback);
@@ -79,7 +79,7 @@ export const createSights = (options: CreateOptions): SightsApi => {
   const getSightPublishStatus: GetSightPublishStatus = (getOptions, callback) => {
     const requestOptions = {
       ...optionsToSend,
-      url: `${options.apiUrls.sights}${getOptions.sightId}/publish`,
+      url: `${options.apiUrls.sights}/${getOptions.sightId}/publish`,
       ...getOptions,
     };
     return requestor.get(requestOptions, callback);
@@ -88,7 +88,7 @@ export const createSights = (options: CreateOptions): SightsApi => {
   const setSightPublishStatus: SetSightPublishStatus = (putOptions, callback) => {
     const requestOptions = {
       ...optionsToSend,
-      url: `${options.apiUrls.sights}${putOptions.sightId}/publish`,
+      url: `${options.apiUrls.sights}/${putOptions.sightId}/publish`,
       ...putOptions,
     };
     return requestor.put(requestOptions, callback);

--- a/lib/utils/apis.ts
+++ b/lib/utils/apis.ts
@@ -1,22 +1,22 @@
 import type { ApiUrls } from '../types';
 
 export const apiUrls: ApiUrls = {
-  contacts: 'contacts/',
-  events: 'events/',
-  favorites: 'favorites/',
-  folders: 'folders/',
-  groups: 'groups/',
-  home: 'home/',
-  imageUrls: 'imageurls/',
-  reports: 'reports/',
-  search: 'search/',
-  server: 'serverinfo/',
-  sheets: 'sheets/',
-  sights: 'sights/',
-  templates: 'templates/',
-  templatesPublic: 'templates/public',
+  contacts: 'contacts',
+  events: 'events',
+  favorites: 'favorites',
+  folders: 'folders',
+  groups: 'groups',
+  home: 'home/', // deprecated
+  imageUrls: 'imageurls',
+  reports: 'reports',
+  search: 'search',
+  server: 'serverinfo',
+  sheets: 'sheets',
+  sights: 'sights',
+  templates: 'templates/', // deprecated
+  templatesPublic: 'templates/public', // deprecated
   token: 'token',
   users: 'users',
-  webhooks: 'webhooks/',
-  workspaces: 'workspaces/',
+  webhooks: 'webhooks',
+  workspaces: 'workspaces',
 };

--- a/lib/utils/apis.ts
+++ b/lib/utils/apis.ts
@@ -6,14 +6,14 @@ export const apiUrls: ApiUrls = {
   favorites: 'favorites',
   folders: 'folders',
   groups: 'groups',
-  home: 'home/', // deprecated
+  home: 'home', // deprecated
   imageUrls: 'imageurls',
   reports: 'reports',
   search: 'search',
   server: 'serverinfo',
   sheets: 'sheets',
   sights: 'sights',
-  templates: 'templates/', // deprecated
+  templates: 'templates', // deprecated
   templatesPublic: 'templates/public', // deprecated
   token: 'token',
   users: 'users',

--- a/lib/webhooks/index.js
+++ b/lib/webhooks/index.js
@@ -35,7 +35,12 @@ exports.create = function (options) {
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
-  var buildUrl = (webhookId) => options.apiUrls.webhooks + (webhookId || '');
+  var buildUrl = (webhookId) => {
+    if (webhookId !== undefined) {
+      return options.apiUrls.webhooks + '/' + webhookId;
+    }
+    return options.apiUrls.webhooks;
+  };
 
   return {
     createWebhook: createWebhook,

--- a/lib/workspaces/index.js
+++ b/lib/workspaces/index.js
@@ -179,7 +179,7 @@ exports.create = function (options) {
   var buildUrl = (urlOptions) => {
     var id = '';
     if (urlOptions && urlOptions.workspaceId) {
-      id = urlOptions.workspaceId;
+      id = '/' + urlOptions.workspaceId;
     }
     return options.apiUrls.workspaces + id;
   };

--- a/test/functional/endpoints_test.js
+++ b/test/functional/endpoints_test.js
@@ -12,57 +12,57 @@ describe('Method Unit Tests', function () {
             name: 'contacts',
             methods: [
                 { name: 'getContact', stub: 'get', options: {}, expectedRequest: {url: "contacts/" }},
-                { name: 'listContacts', stub: 'get', options: undefined, expectedRequest: {url: "contacts/" }},
+                { name: 'listContacts', stub: 'get', options: undefined, expectedRequest: {url: "contacts" }},
             ]
         },
         {
             name: 'events',
             methods: [
-                { name: 'getEvents', stub: 'get', options: {}, expectedRequest: {url: "events/" }}
+                { name: 'getEvents', stub: 'get', options: {}, expectedRequest: {url: "events" }}
             ]
         },
         {
             name: 'favorites',
             methods: [
-                { name: 'listFavorites', stub: 'get', options: undefined, expectedRequest: {url: "favorites/" }},
-                { name: 'addItemsToFavorites', stub: 'post', options: {}, expectedRequest: {url: "favorites/" }},
-                { name: 'addSheetToFavorites', stub: 'post', options: { objectId: 123 }, expectedRequest: {url: "favorites/", body: { objectId: 123, type: 'sheet' } }},
-                { name: 'addFolderToFavorites', stub: 'post', options: { objectId: 123 }, expectedRequest: {url: "favorites/", body: { objectId: 123, type: 'folder' } }},
-                { name: 'addReportToFavorites', stub: 'post', options: { objectId: 123 }, expectedRequest: {url: "favorites/", body: { objectId: 123, type: 'report' } }},
-                { name: 'addTemplateToFavorites', stub: 'post', options: { objectId: 123 }, expectedRequest: {url: "favorites/", body: { objectId: 123, type: 'template' } }},
-                { name: 'addSightToFavorites', stub: 'post', options: { objectId: 123 }, expectedRequest: {url: "favorites/", body: { objectId: 123, type: 'sight' } }},
-                { name: 'addWorkspaceToFavorites', stub: 'post', options: { objectId: 123 }, expectedRequest: {url: "favorites/", body: { objectId: 123, type: 'workspace' } }},
-                { name: 'addMultipleToFavorites', stub: 'post', options: { body: [{objectId: 123, type: 'workspace'}] }, expectedRequest: {url: "favorites/", body: [{ objectId: 123, type: 'workspace' }] }},
+                { name: 'listFavorites', stub: 'get', options: undefined, expectedRequest: {url: "favorites" }},
+                { name: 'addItemsToFavorites', stub: 'post', options: {}, expectedRequest: {url: "favorites" }},
+                { name: 'addSheetToFavorites', stub: 'post', options: { objectId: 123 }, expectedRequest: {url: "favorites", body: { objectId: 123, type: 'sheet' } }},
+                { name: 'addFolderToFavorites', stub: 'post', options: { objectId: 123 }, expectedRequest: {url: "favorites", body: { objectId: 123, type: 'folder' } }},
+                { name: 'addReportToFavorites', stub: 'post', options: { objectId: 123 }, expectedRequest: {url: "favorites", body: { objectId: 123, type: 'report' } }},
+                { name: 'addTemplateToFavorites', stub: 'post', options: { objectId: 123 }, expectedRequest: {url: "favorites", body: { objectId: 123, type: 'template' } }},
+                { name: 'addSightToFavorites', stub: 'post', options: { objectId: 123 }, expectedRequest: {url: "favorites", body: { objectId: 123, type: 'sight' } }},
+                { name: 'addWorkspaceToFavorites', stub: 'post', options: { objectId: 123 }, expectedRequest: {url: "favorites", body: { objectId: 123, type: 'workspace' } }},
+                { name: 'addMultipleToFavorites', stub: 'post', options: { body: [{objectId: 123, type: 'workspace'}] }, expectedRequest: {url: "favorites", body: [{ objectId: 123, type: 'workspace' }] }},
                 { name: 'removeSheetFromFavorites', stub: 'delete', options: { objectId: 123 }, expectedRequest: {url: "favorites/sheet/123" }},
                 { name: 'removeFolderFromFavorites', stub: 'delete', options: { objectId: 123 }, expectedRequest: {url: "favorites/folder/123" }},
                 { name: 'removeReportFromFavorites', stub: 'delete', options: { objectId: 123 }, expectedRequest: {url: "favorites/report/123" }},
                 { name: 'removeTemplateFromFavorites', stub: 'delete', options: { objectId: 123 }, expectedRequest: {url: "favorites/template/123" }},
                 { name: 'removeSightFromFavorites', stub: 'delete', options: { objectId: 123 }, expectedRequest: {url: "favorites/sight/123" }},
                 { name: 'removeWorkspaceFromFavorites', stub: 'delete', options: { objectId: 123 }, expectedRequest: {url: "favorites/workspace/123" }},
-                { name: 'removeSheetsFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: [123, 234] }}, expectedRequest: {url: "favorites/sheet/", queryParameters: {objectIds: '123,234'}}},
-                { name: 'removeFoldersFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: [123, 234] }}, expectedRequest: {url: "favorites/folder/", queryParameters: {objectIds: '123,234'} }},
-                { name: 'removeReportsFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: [123, 234] }}, expectedRequest: {url: "favorites/report/", queryParameters: {objectIds: '123,234'} }},
-                { name: 'removeTemplatesFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: [123, 234] }}, expectedRequest: {url: "favorites/template/", queryParameters: {objectIds: '123,234'} }},
-                { name: 'removeSightsFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: [123, 234] }}, expectedRequest: {url: "favorites/sight/", queryParameters: {objectIds: '123,234'} }},
-                { name: 'removeWorkspacesFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: [123, 234] }}, expectedRequest: {url: "favorites/workspace/", queryParameters: {objectIds: '123,234'} }},
-                { name: 'removeSheetsFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: '123,234'} }, expectedRequest: {url: "favorites/sheet/", queryParameters: {objectIds: '123,234'} }},
-                { name: 'removeFoldersFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: '123,234'} }, expectedRequest: {url: "favorites/folder/", queryParameters: {objectIds: '123,234'} }},
-                { name: 'removeReportsFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: '123,234'} }, expectedRequest: {url: "favorites/report/", queryParameters: {objectIds: '123,234'} }},
-                { name: 'removeTemplatesFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: '123,234'} }, expectedRequest: {url: "favorites/template/", queryParameters: {objectIds: '123,234'} }},
-                { name: 'removeSightsFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: '123,234'} }, expectedRequest: {url: "favorites/sight/", queryParameters: {objectIds: '123,234'} }},
-                { name: 'removeWorkspacesFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: '123,234'} }, expectedRequest: {url: "favorites/workspace/", queryParameters: {objectIds: '123,234'} }},
+                { name: 'removeSheetsFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: [123, 234] }}, expectedRequest: {url: "favorites/sheet", queryParameters: {objectIds: '123,234'}}},
+                { name: 'removeFoldersFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: [123, 234] }}, expectedRequest: {url: "favorites/folder", queryParameters: {objectIds: '123,234'} }},
+                { name: 'removeReportsFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: [123, 234] }}, expectedRequest: {url: "favorites/report", queryParameters: {objectIds: '123,234'} }},
+                { name: 'removeTemplatesFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: [123, 234] }}, expectedRequest: {url: "favorites/template", queryParameters: {objectIds: '123,234'} }},
+                { name: 'removeSightsFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: [123, 234] }}, expectedRequest: {url: "favorites/sight", queryParameters: {objectIds: '123,234'} }},
+                { name: 'removeWorkspacesFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: [123, 234] }}, expectedRequest: {url: "favorites/workspace", queryParameters: {objectIds: '123,234'} }},
+                { name: 'removeSheetsFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: '123,234'} }, expectedRequest: {url: "favorites/sheet", queryParameters: {objectIds: '123,234'} }},
+                { name: 'removeFoldersFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: '123,234'} }, expectedRequest: {url: "favorites/folder", queryParameters: {objectIds: '123,234'} }},
+                { name: 'removeReportsFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: '123,234'} }, expectedRequest: {url: "favorites/report", queryParameters: {objectIds: '123,234'} }},
+                { name: 'removeTemplatesFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: '123,234'} }, expectedRequest: {url: "favorites/template", queryParameters: {objectIds: '123,234'} }},
+                { name: 'removeSightsFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: '123,234'} }, expectedRequest: {url: "favorites/sight", queryParameters: {objectIds: '123,234'} }},
+                { name: 'removeWorkspacesFromFavorites', stub: 'delete', options: { queryParameters: {objectIds: '123,234'} }, expectedRequest: {url: "favorites/workspace", queryParameters: {objectIds: '123,234'} }},
             ]
         },
         {
             name: 'folders',
             methods: [
-                { name: 'getFolder', stub: 'get', options: {}, expectedRequest: {url: "folders/" }},
+                { name: 'getFolder', stub: 'get', options: {}, expectedRequest: {url: "folders" }},
                 { name: 'getFolderMetadata', stub: 'get', options: {folderId: 123}, expectedRequest: {url: "folders/123/metadata" }},
                 { name: 'getFolderChildren', stub: 'get', options: {folderId: 123}, expectedRequest: {url: "folders/123/children" }},
                 { name: 'listChildFolders', stub: 'get', options: {folderId: 123}, expectedRequest: {url: "folders/123/folders" }},
                 { name: 'createChildFolder', stub: 'post', options: {folderId: 123}, expectedRequest: {url: "folders/123/folders" }},
-                { name: 'updateFolder', stub: 'put', options: {folderId: 123}, expectedRequest: {url: "folders/" }},
-                { name: 'deleteFolder', stub: 'delete', options: {folderId: 123}, expectedRequest: {url: "folders/" }},
+                { name: 'updateFolder', stub: 'put', options: {folderId: 123}, expectedRequest: {url: "folders/123" }},
+                { name: 'deleteFolder', stub: 'delete', options: {folderId: 123}, expectedRequest: {url: "folders/123" }},
                 { name: 'moveFolder', stub: 'post', options: {folderId: 123}, expectedRequest: {url: "folders/123/move" }},
                 { name: 'copyFolder', stub: 'post', options: {folderId: 123}, expectedRequest: {url: "folders/123/copy" }},
             ]
@@ -70,19 +70,19 @@ describe('Method Unit Tests', function () {
         {
             name: 'groups',
             methods: [
-                { name: 'getGroup', stub: 'get', options: {}, expectedRequest: {url: "groups/" }},
-                { name: 'listGroups', stub: 'get', options: undefined, expectedRequest: {url: "groups/" }},
-                { name: 'createGroup', stub: 'post', options: {}, expectedRequest: {url: "groups/" }},
-                { name: 'addGroupMembers', stub: 'post', options: {groupId: 123}, expectedRequest: {url: "groups/123/members/" }},
-                { name: 'updateGroup', stub: 'put', options: {}, expectedRequest: {url: "groups/" }},
-                { name: 'deleteGroup', stub: 'delete', options: {}, expectedRequest: {url: "groups/" }},
+                { name: 'getGroup', stub: 'get', options: {}, expectedRequest: {url: "groups" }},
+                { name: 'listGroups', stub: 'get', options: undefined, expectedRequest: {url: "groups" }},
+                { name: 'createGroup', stub: 'post', options: {}, expectedRequest: {url: "groups" }},
+                { name: 'addGroupMembers', stub: 'post', options: {groupId: 123}, expectedRequest: {url: "groups/123/members" }},
+                { name: 'updateGroup', stub: 'put', options: {groupId: 123}, expectedRequest: {url: "groups/123" }},
+                { name: 'deleteGroup', stub: 'delete', options: {groupId: 123}, expectedRequest: {url: "groups/123" }},
                 { name: 'removeGroupMember', stub: 'delete', options: {groupId: 123, userId: 234}, expectedRequest: {url: "groups/123/members/234" }},
             ]
         },
         {
             name: 'home',
             methods: [
-                { name: 'listContents', stub: 'get', options: undefined, expectedRequest: {url: "home/" }},
+                { name: 'listContents', stub: 'get', options: undefined, expectedRequest: {url: "home" }},
                 { name: 'listFolders', stub: 'get', options: undefined, expectedRequest: {url: "home/folders" }},
                 { name: 'createFolder', stub: 'post', options: {}, expectedRequest: {url: "home/folders" }},
             ]
@@ -90,17 +90,17 @@ describe('Method Unit Tests', function () {
         {
             name: 'images',
             methods: [
-                { name: 'listImageUrls', stub: 'post', options: {}, expectedRequest: {url: "imageurls/" }},
+                { name: 'listImageUrls', stub: 'post', options: {}, expectedRequest: {url: "imageurls" }},
             ]
         },
         {
             name: 'reports',
             methods: [
-                { name: 'getReport', stub: 'get', options: {}, expectedRequest: {url: "reports/" }},
-                { name: 'listReports', stub: 'get', options: undefined, expectedRequest: {url: "reports/"}},
+                { name: 'getReport', stub: 'get', options: {reportId: 123}, expectedRequest: {url: "reports/123" }},
+                { name: 'listReports', stub: 'get', options: {}, expectedRequest: {url: "reports"}},
                 { name: 'sendReportViaEmail', stub: 'post', options: {reportId: 123}, expectedRequest: {url: "reports/123/emails" }},
-                { name: 'getReportAsExcel', stub: 'get', options: {}, expectedRequest: {url: "reports/", accept: constants.acceptHeaders.vndMsExcel, encoding:null }},
-                { name: 'getReportAsCSV', stub: 'get', options: {}, expectedRequest: {url: "reports/", accept: constants.acceptHeaders.textCsv }},
+                { name: 'getReportAsExcel', stub: 'get', options: {reportId: 123}, expectedRequest: {url: "reports/123", accept: constants.acceptHeaders.vndMsExcel, encoding:null }},
+                { name: 'getReportAsCSV', stub: 'get', options: {reportId: 123}, expectedRequest: {url: "reports/123", accept: constants.acceptHeaders.textCsv }},
                 { name: 'getReportPublishStatus', stub: 'get', options: {reportId: 123}, expectedRequest: {url: "reports/123/publish" }},
                 { name: 'setReportPublishStatus', stub: 'put', options: {reportId: 123}, expectedRequest: {url: "reports/123/publish" }},
             ]
@@ -118,16 +118,16 @@ describe('Method Unit Tests', function () {
         {
             name: 'search',
             methods: [
-                { name: 'searchAll', stub: 'get', options: {query: "query"}, expectedRequest: {url: "search/", queryParameters: {query: "query"}}},
-                { name: 'searchAll', stub: 'get', options: {query: "query", queryParameters: {someParam: "something"}}, expectedRequest: {url: "search/", queryParameters: {query: "query", someParam: "something"}}},
-                { name: 'searchAll', stub: 'get', options: {query: "query"}, expectedRequest: {url: "search/", queryParameters: {query: "query"}}},
-                { name: 'searchSheet', stub: 'get', options: {query: "query", sheetId: 123}, expectedRequest: {url: "search/", queryParameters: {query: "query", sheetId: 123}}},
+                { name: 'searchAll', stub: 'get', options: {query: "query"}, expectedRequest: {url: "search", queryParameters: {query: "query"}}},
+                { name: 'searchAll', stub: 'get', options: {query: "query", queryParameters: {someParam: "something"}}, expectedRequest: {url: "search", queryParameters: {query: "query", someParam: "something"}}},
+                { name: 'searchAll', stub: 'get', options: {query: "query"}, expectedRequest: {url: "search", queryParameters: {query: "query"}}},
+                { name: 'searchSheet', stub: 'get', options: {query: "query", sheetId: 1}, expectedRequest: {url: "search/sheets/1", queryParameters: {query: "query"}}},
             ]
         },
         {
             name: 'server',
             methods: [
-                { name: 'getInfo', stub: 'get', options: undefined, expectedRequest: {url: "serverinfo/"}},
+                { name: 'getInfo', stub: 'get', options: undefined, expectedRequest: {url: "serverinfo"}},
             ]
         },
         {
@@ -136,28 +136,28 @@ describe('Method Unit Tests', function () {
                 { name: 'sendSheetViaEmail', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/emails"}},
                 { name: 'getPublishStatus', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/publish"}},
                 { name: 'setPublishStatus', stub: 'put', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/publish"}},
-                { name: 'updateSheet', stub: 'put', options: {}, expectedRequest: {url: "sheets/"}},
-                { name: 'deleteSheet', stub: 'delete', options: {}, expectedRequest: {url: "sheets/"}},
+                { name: 'updateSheet', stub: 'put', options: {sheetId: 123}, expectedRequest: {url: "sheets/123"}},
+                { name: 'deleteSheet', stub: 'delete', options: {sheetId: 123}, expectedRequest: {url: "sheets/123"}},
                 { name: 'moveSheet', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/move"}},
                 { name: 'sortRowsInSheet', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/sort"}},
                 // attachments
-                { name: 'listAttachments', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/attachments/"}},
+                { name: 'listAttachments', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/attachments"}},
                 { name: 'listAttachmentVersions', stub: 'get', options: {sheetId: 123, attachmentId: 234}, expectedRequest: {url: "sheets/123/attachments/234/versions"}},
-                { name: 'addUrlAttachment', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/attachments/"}},
-                { name: 'addAttachment', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/attachments/"}},
-                { name: 'addFileAttachment', stub: 'postFile', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/attachments/"}},
+                { name: 'addUrlAttachment', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/attachments"}},
+                { name: 'addAttachment', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/attachments"}},
+                { name: 'addFileAttachment', stub: 'postFile', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/attachments"}},
                 { name: 'attachNewVersion', stub: 'postFile', options: {sheetId: 123, attachmentId: 234}, expectedRequest: {url: "sheets/123/attachments/234/versions"}},
-                { name: 'deleteAttachment', stub: 'delete', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/attachments/"}},
+                { name: 'deleteAttachment', stub: 'delete', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/attachments"}},
                 { name: 'deleteAllAttachmentVersions', stub: 'delete', options: {sheetId: 123, attachmentId: 234}, expectedRequest: {url: "sheets/123/attachments/234/versions"}},
                 // automation rules
                 { name: 'deleteAutomationRule', stub: 'delete', options: {sheetId: 123, automationRuleId: 234}, expectedRequest: {url: "sheets/123/automationrules/234"}},
                 { name: 'getAutomationRule', stub: 'get', options: {sheetId: 123, automationRuleId: 234}, expectedRequest: {url: "sheets/123/automationrules/234"}},
-                { name: 'listAutomationRules', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/automationrules/"}},
+                { name: 'listAutomationRules', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/automationrules"}},
                 { name: 'updateAutomationRule', stub: 'put', options: {sheetId: 123, automationRuleId: 234}, expectedRequest: {url: "sheets/123/automationrules/234"}},
                 // columns
-                { name: 'getColumns', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/columns/"}},
+                { name: 'getColumns', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/columns"}},
                 { name: 'getColumn', stub: 'get', options: {sheetId: 123, columnId: 234}, expectedRequest: {url: "sheets/123/columns/234"}},
-                { name: 'addColumn', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/columns/"}},
+                { name: 'addColumn', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/columns"}},
                 { name: 'updateColumn', stub: 'put', options: {sheetId: 123, columnId: 234}, expectedRequest: {url: "sheets/123/columns/234"}},
                 { name: 'deleteColumn', stub: 'delete', options: {sheetId: 123, columnId: 234}, expectedRequest: {url: "sheets/123/columns/234"}},
                 // comments
@@ -168,8 +168,8 @@ describe('Method Unit Tests', function () {
                 { name: 'addCommentFileAttachment', stub: 'postFile', options: {sheetId: 123, commentId: 234}, expectedRequest: {url: "sheets/123/comments/234/attachments"}},
                 { name: 'editComment', stub: 'put', options: {sheetId: 123, commentId: 234}, expectedRequest: {url: "sheets/123/comments/234"}},
                 // create
-                { name: 'createSheet', stub: 'post', options: {}, expectedRequest: {url: "sheets/"}},
-                { name: 'createSheetFromExisting', stub: 'post', options: {}, expectedRequest: {url: "sheets/"}},
+                { name: 'createSheet', stub: 'post', options: {}, expectedRequest: {url: "sheets"}},
+                { name: 'createSheetFromExisting', stub: 'post', options: {}, expectedRequest: {url: "sheets"}},
                 { name: 'createSheetFromExisting', stub: 'post', options: {folderId: 123}, expectedRequest: {url: "folders/123/sheets"}},
                 { name: 'createSheetFromExisting', stub: 'post', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123/sheets"}},
                 { name: 'createSheetInFolder', stub: 'post', options: {folderId: 123}, expectedRequest: {url: "folders/123/sheets"}},
@@ -185,22 +185,22 @@ describe('Method Unit Tests', function () {
                 { name: 'importXlsxSheetIntoWorkspace', stub: 'postFile', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123/sheets/import", contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", contentDisposition: 'attachment'}},
                 { name: 'importCsvSheetIntoWorkspace', stub: 'postFile', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123/sheets/import", contentType: "text/csv", contentDisposition: 'attachment'}},
                 // cross sheet references
-                { name: 'createCrossSheetReference', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/crosssheetreferences/"}},
+                { name: 'createCrossSheetReference', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/crosssheetreferences"}},
                 { name: 'getCrossSheetReference', stub: 'get', options: {sheetId: 123, crossSheetReferenceId: 234}, expectedRequest: {url: "sheets/123/crosssheetreferences/234"}},
-                { name: 'listCrossSheetReferences', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/crosssheetreferences/"}},
+                { name: 'listCrossSheetReferences', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/crosssheetreferences"}},
                 // discussions
-                { name: 'getDiscussions', stub: 'get', options: {sheetId:123}, expectedRequest: {url: "sheets/123/discussions/"}},
+                { name: 'getDiscussions', stub: 'get', options: {sheetId:123}, expectedRequest: {url: "sheets/123/discussions"}},
                 { name: 'getDiscussion', stub: 'get', options: {sheetId:123, discussionId: 234}, expectedRequest: {url: "sheets/123/discussions/234"}},
                 { name: 'listDiscussionAttachments', stub: 'get', options: {sheetId:123, discussionId: 234}, expectedRequest: {url: "sheets/123/discussions/234/attachments"}},
-                { name: 'createDiscussion', stub: 'post', options: {sheetId:123}, expectedRequest: {url: "sheets/123/discussions/"}},
+                { name: 'createDiscussion', stub: 'post', options: {sheetId:123}, expectedRequest: {url: "sheets/123/discussions"}},
                 { name: 'addDiscussionComment', stub: 'post', options: {sheetId:123, discussionId: 234}, expectedRequest: {url: "sheets/123/discussions/234/comments"}},
                 { name: 'deleteDiscussion', stub: 'delete', options: {sheetId:123, discussionId: 234}, expectedRequest: {url: "sheets/123/discussions/234"}},
                 // get
-                { name: 'getSheet', stub: 'get', options: {}, expectedRequest: {url: "sheets/"}},
-                { name: 'listSheets', stub: 'get', options: undefined, expectedRequest: {url: "sheets/"}},
-                { name: 'getSheetAsCSV', stub: 'get', options: {}, expectedRequest: {url: "sheets/", accept: constants.acceptHeaders.textCsv}},
-                { name: 'getSheetAsExcel', stub: 'get', options: {}, expectedRequest: {url: "sheets/", accept: constants.acceptHeaders.vndMsExcel, encoding:null}},
-                { name: 'getSheetAsPDF', stub: 'get', options: {}, expectedRequest: {url: "sheets/", accept: constants.acceptHeaders.applicationPdf, encoding:null}},
+                { name: 'getSheet', stub: 'get', options: {}, expectedRequest: {url: "sheets"}},
+                { name: 'listSheets', stub: 'get', options: undefined, expectedRequest: {url: "sheets"}},
+                { name: 'getSheetAsCSV', stub: 'get', options: {}, expectedRequest: {url: "sheets", accept: constants.acceptHeaders.textCsv}},
+                { name: 'getSheetAsExcel', stub: 'get', options: {}, expectedRequest: {url: "sheets", accept: constants.acceptHeaders.vndMsExcel, encoding:null}},
+                { name: 'getSheetAsPDF', stub: 'get', options: {}, expectedRequest: {url: "sheets", accept: constants.acceptHeaders.applicationPdf, encoding:null}},
                 { name: 'getSheetVersion', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/version"}},
                 { name: 'listOrganizationSheets', stub: 'get', options: undefined, expectedRequest: {url: "users/sheets"}},
                 // summaries
@@ -231,19 +231,19 @@ describe('Method Unit Tests', function () {
                 { name: 'updateRow', stub: 'put', options: {sheetId: 123, rowId: 234}, expectedRequest: {url: "sheets/123/rows"}},
                 { name: 'addImageToCell', stub: 'postFile', options: {sheetId: 123, rowId: 234, columnId: 345}, expectedRequest: {url: "sheets/123/rows/234/columns/345/cellimages"}},
                 // update requests
-                { name: 'createUpdateRequest', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/updaterequests/"}},
+                { name: 'createUpdateRequest', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/updaterequests"}},
                 { name: 'deleteUpdateRequest', stub: 'delete', options: {sheetId: 123, updateRequestId: 234}, expectedRequest: {url: "sheets/123/updaterequests/234"}},
                 { name: 'getUpdateRequest', stub: 'get', options: {sheetId: 123, updateRequestId: 234}, expectedRequest: {url: "sheets/123/updaterequests/234"}},
-                { name: 'getAllUpdateRequests', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/updaterequests/"}},
+                { name: 'getAllUpdateRequests', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/updaterequests"}},
                 { name: 'changeUpdateRequest', stub: 'put', options: {sheetId: 123, updateRequestId: 234}, expectedRequest: {url: "sheets/123/updaterequests/234"}},
                 // sent update requests
                 { name: 'deleteSentUpdateRequest', stub: 'delete', options: {sheetId: 123, sentUpdateRequestId: 234}, expectedRequest: {url: "sheets/123/sentupdaterequests/234"}},
                 { name: 'getSentUpdateRequest', stub: 'get', options: {sheetId: 123, sentUpdateRequestId: 234}, expectedRequest: {url: "sheets/123/sentupdaterequests/234"}},
-                { name: 'getAllSentUpdateRequests', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/sentupdaterequests/"}},
+                { name: 'getAllSentUpdateRequests', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/sentupdaterequests"}},
                 // shares
                 { name: 'getShare', stub: 'get', options: {sheetId: 123, shareId: 234}, expectedRequest: {url: "sheets/123/shares/234"}},
-                { name: 'listShares', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/shares/"}},
-                { name: 'share', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/shares/"}},
+                { name: 'listShares', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/shares"}},
+                { name: 'share', stub: 'post', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/shares"}},
                 { name: 'deleteShare', stub: 'delete', options: {sheetId: 123, shareId: 234}, expectedRequest: {url: "sheets/123/shares/234"}},
                 { name: 'updateShare', stub: 'put', options: {sheetId: 123, shareId: 234}, expectedRequest: {url: "sheets/123/shares/234"}},
             ]
@@ -251,7 +251,7 @@ describe('Method Unit Tests', function () {
         {
             name: 'sights',
             methods: [
-                { name: 'listSights', stub: 'get', options: undefined, expectedRequest: {url: "sights/"}},
+                { name: 'listSights', stub: 'get', options: undefined, expectedRequest: {url: "sights"}},
                 { name: 'getSight', stub: 'get', options: {sightId:123}, expectedRequest: {url: "sights/123"}},
                 { name: 'deleteSight', stub: 'delete', options: {sightId:123}, expectedRequest: {url: "sights/123"}},
                 { name: 'updateSight', stub: 'put', options: {sightId:123}, expectedRequest: {url: "sights/123"}},
@@ -264,7 +264,7 @@ describe('Method Unit Tests', function () {
         {
             name: 'templates',
             methods: [
-                { name: 'listUserCreatedTemplates', stub: 'get', options: undefined, expectedRequest: {url: "templates/"}},
+                { name: 'listUserCreatedTemplates', stub: 'get', options: undefined, expectedRequest: {url: "templates"}},
                 { name: 'listPublicTemplates', stub: 'get', options: undefined, expectedRequest: {url: "templates/public"}},
             ]
         },
@@ -305,26 +305,26 @@ describe('Method Unit Tests', function () {
         {
             name: 'webhooks',
             methods: [
-                { name: 'createWebhook', stub: 'post', options: {}, expectedRequest: {url: "webhooks/" }},
+                { name: 'createWebhook', stub: 'post', options: {}, expectedRequest: {url: "webhooks" }},
                 { name: 'deleteWebhook', stub: 'delete', options: { webhookId: 123 }, expectedRequest: {url: "webhooks/123" }},
                 { name: 'updateWebhook', stub: 'put', options: { webhookId: 123 }, expectedRequest: {url: "webhooks/123" }},
                 { name: 'getWebhook', stub: 'get', options: { webhookId: 123 }, expectedRequest: {url: "webhooks/123" }},
-                { name: 'listWebhooks', stub: 'get', options: undefined, expectedRequest: {url: "webhooks/" }},
+                { name: 'listWebhooks', stub: 'get', options: undefined, expectedRequest: {url: "webhooks" }},
                 { name: 'resetSharedSecret', stub: 'post', options: { webhookId: 123 }, expectedRequest: {url: "webhooks/123/resetsharedsecret" }},
             ]
         },
         {
             name: 'workspaces',
             methods: [
-                { name: 'listWorkspaces', stub: 'get', options: undefined, expectedRequest: {url: "workspaces/"}},
-                { name: 'listWorkspaces', stub: 'get', options: {queryParameters : {paginationType: 'token', lastKey: 'abc123'}}, expectedRequest: {url: "workspaces/", queryParameters: {paginationType: 'token', lastKey: 'abc123'}}},
-                { name: 'listWorkspaces', stub: 'get', options: {queryParameters : {paginationType: 'token', maxItems: 500}}, expectedRequest: {url: "workspaces/", queryParameters: {paginationType: 'token', maxItems: 500}}},
-                { name: 'listWorkspaces', stub: 'get', options: {queryParameters : {paginationType: 'token', lastKey: 'abc123', maxItems: 100}}, expectedRequest: {url: "workspaces/", queryParameters: {paginationType: 'token', lastKey: 'abc123', maxItems: 100}}},
+                { name: 'listWorkspaces', stub: 'get', options: undefined, expectedRequest: {url: "workspaces"}},
+                { name: 'listWorkspaces', stub: 'get', options: {queryParameters : {paginationType: 'token', lastKey: 'abc123'}}, expectedRequest: {url: "workspaces", queryParameters: {paginationType: 'token', lastKey: 'abc123'}}},
+                { name: 'listWorkspaces', stub: 'get', options: {queryParameters : {paginationType: 'token', maxItems: 500}}, expectedRequest: {url: "workspaces", queryParameters: {paginationType: 'token', maxItems: 500}}},
+                { name: 'listWorkspaces', stub: 'get', options: {queryParameters : {paginationType: 'token', lastKey: 'abc123', maxItems: 100}}, expectedRequest: {url: "workspaces", queryParameters: {paginationType: 'token', lastKey: 'abc123', maxItems: 100}}},
                 { name: 'getWorkspace', stub: 'get', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123"}},
                 { name: 'getWorkspaceMetadata', stub: 'get', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123/metadata"}},
                 { name: 'getWorkspaceChildren', stub: 'get', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123/children"}},
                 { name: 'listWorkspaceFolders', stub: 'get', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123/folders"}},
-                { name: 'createWorkspace', stub: 'post', options: {}, expectedRequest: {url: "workspaces/"}},
+                { name: 'createWorkspace', stub: 'post', options: {}, expectedRequest: {url: "workspaces"}},
                 { name: 'createFolder', stub: 'post', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123/folders"}},
                 { name: 'deleteWorkspace', stub: 'delete', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123"}},
                 { name: 'updateWorkspace', stub: 'put', options: {workspaceId: 123}, expectedRequest: {url: "workspaces/123"}},

--- a/test/functional/endpoints_test.js
+++ b/test/functional/endpoints_test.js
@@ -97,7 +97,7 @@ describe('Method Unit Tests', function () {
             name: 'reports',
             methods: [
                 { name: 'getReport', stub: 'get', options: {reportId: 123}, expectedRequest: {url: "reports/123" }},
-                { name: 'listReports', stub: 'get', options: {}, expectedRequest: {url: "reports"}},
+                { name: 'listReports', stub: 'get', options: undefined, expectedRequest: {url: "reports"}},
                 { name: 'sendReportViaEmail', stub: 'post', options: {reportId: 123}, expectedRequest: {url: "reports/123/emails" }},
                 { name: 'getReportAsExcel', stub: 'get', options: {reportId: 123}, expectedRequest: {url: "reports/123", accept: constants.acceptHeaders.vndMsExcel, encoding:null }},
                 { name: 'getReportAsCSV', stub: 'get', options: {reportId: 123}, expectedRequest: {url: "reports/123", accept: constants.acceptHeaders.textCsv }},

--- a/test/functional/sheets_test.js
+++ b/test/functional/sheets_test.js
@@ -21,7 +21,7 @@ describe('Client Unit Tests', function() {
     it('should not change base URL when getSheetVersion is called first', function() {
       // First call to getSheet
       smartsheet.sheets.getSheet({ id: 100 });
-      should(requestor.get.firstCall.args[0]).have.property('url', 'sheets/');
+      should(requestor.get.firstCall.args[0]).have.property('url', 'sheets');
 
       // First call to getSheetVersion
       smartsheet.sheets.getSheetVersion({ sheetId: 100 });
@@ -29,13 +29,13 @@ describe('Client Unit Tests', function() {
 
       // Second call to getSheet
       smartsheet.sheets.getSheet({ id: 100 });
-      should(requestor.get.thirdCall.args[0]).have.property('url', 'sheets/');
+      should(requestor.get.thirdCall.args[0]).have.property('url', 'sheets');
     });
 
     it('should not change base URL when getOrganizationSheets is called first', function () {
       // First call to getSheet
       smartsheet.sheets.getSheet({ id: 100 });
-      should(requestor.get.firstCall.args[0]).have.property('url', 'sheets/');
+      should(requestor.get.firstCall.args[0]).have.property('url', 'sheets');
 
       // First call to getSheetVersion
       smartsheet.sheets.listOrganizationSheets();
@@ -43,7 +43,7 @@ describe('Client Unit Tests', function() {
 
       // Second call to getSheet
       smartsheet.sheets.getSheet({ id: 100 });
-      should(requestor.get.thirdCall.args[0]).have.property('url', 'sheets/');
+      should(requestor.get.thirdCall.args[0]).have.property('url', 'sheets');
     });
   });
 });


### PR DESCRIPTION
The URL generation in the SDK was adding a trailing slash to some endpoints (e.g. /users). The API does not complain about this however this is not consistent with the rest of the SDKs.