### PR TITLE
Prepare release 4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [x.x.x] - Unreleased
+## [4.7.1] - 2026-02-12
 ### Added
 - WiremMock integration tests for contract testing for GET /2.0/users/{userId}/plans and GET /2.0/users endpoints
 - WireMock integration tests for contract testing for POST /2.0/users/{userId}/plans/{planId}/upgrade and POST /2.0/users/{userId}/plans/{planId}/downgrade

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smartsheet",
-  "version": "4.8.0",
+  "version": "4.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smartsheet",
-      "version": "4.8.0",
+      "version": "4.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "4.8.0",
+  "version": "4.7.1",
   "description": "Smartsheet JavaScript client SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
The version in package.json is lowered from 4.8.0 to 4.7.1 cause the latest release in npmjs is 4.7.0.
v4.8.0 was introduced by a mistake and was not reverted. However the version in CHANGELOG.md was reverted with https://github.com/smartsheet/smartsheet-javascript-sdk/commit/f64e27de57f8fa1d64b6a760a60818c49156ba98.