### PR TITLE
Fix log level check causing crashes.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,7 +69,7 @@ function hasMultipleLogOptions(clientOptions) {
 }
 
 function buildLoggerFromLevel(logLevel) {
-  if (winston.level[logLevel] == null) {
+  if (winston.config.npm.levels[logLevel] == null) {
     throw new Error(
       'Smartsheet client received configuration with invalid log level ' +
         `'${logLevel}'. Use one of the standard Winston log levels.`

--- a/lib/types/CreateClientOptions.ts
+++ b/lib/types/CreateClientOptions.ts
@@ -8,6 +8,6 @@ export interface CreateClientOptions {
   maxRetryDurationSeconds?: number;
   calcRetryBackoff?: (retryCount: number, error?: any) => number;
   logger?: LoggerInstance;
-  logLevel?: 'error' | 'warn' | 'info' | 'http' | 'info' | 'verbose' | 'debug' | 'silly';
+  logLevel?: 'error' | 'warn' | 'info' | 'verbose' | 'debug' | 'silly';
   loggerContainer?: any;
 }

--- a/test/functional/client.spec.ts
+++ b/test/functional/client.spec.ts
@@ -488,6 +488,12 @@ describe('Client Unit Tests', () => {
       }).not.toThrow();
     });
 
+    it('should not throw when logLevel is set to "silly"', () => {
+      expect(() => {
+        smartsheetModule.createClient({ accessToken: '1234', logLevel: 'silly' });
+      }).not.toThrow();
+    });
+
     it('should throw when logLevel is set to an invalid value', () => {
       expect(() => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/test/functional/client.spec.ts
+++ b/test/functional/client.spec.ts
@@ -457,5 +457,43 @@ describe('Client Unit Tests', () => {
     });
   });
 
+  describe('#createClient with logLevel', () => {
+    it('should not throw when logLevel is set to "info"', () => {
+      expect(() => {
+        smartsheetModule.createClient({ accessToken: '1234', logLevel: 'info' });
+      }).not.toThrow();
+    });
+
+    it('should not throw when logLevel is set to "warn"', () => {
+      expect(() => {
+        smartsheetModule.createClient({ accessToken: '1234', logLevel: 'warn' });
+      }).not.toThrow();
+    });
+
+    it('should not throw when logLevel is set to "error"', () => {
+      expect(() => {
+        smartsheetModule.createClient({ accessToken: '1234', logLevel: 'error' });
+      }).not.toThrow();
+    });
+
+    it('should not throw when logLevel is set to "verbose"', () => {
+      expect(() => {
+        smartsheetModule.createClient({ accessToken: '1234', logLevel: 'verbose' });
+      }).not.toThrow();
+    });
+
+    it('should not throw when logLevel is set to "debug"', () => {
+      expect(() => {
+        smartsheetModule.createClient({ accessToken: '1234', logLevel: 'debug' });
+      }).not.toThrow();
+    });
+
+    it('should throw when logLevel is set to an invalid value', () => {
+      expect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        smartsheetModule.createClient({ accessToken: '1234', logLevel: 'invalidLevel' as any });
+      }).toThrow();
+    });
+  });
 
 });

--- a/test/mock-api/utils/utils.ts
+++ b/test/mock-api/utils/utils.ts
@@ -7,7 +7,8 @@ const wiremockUrl = 'http://127.0.0.1:8082';
 export function createClient() {
     return smartsheet.createClient({
         accessToken: 'test_token',
-        baseUrl: baseUrl
+        baseUrl: baseUrl,
+        logLevel: 'info',
     });
 }
 


### PR DESCRIPTION
Issue: #158 

After upgrading to v4.7.1, applications using the `logLevel` option crashed immediately on client initialization.

This PR fixes it and adds tests for it. Additionally mock API tests now configure logger as an additional check in a real use case.