### PR TITLE
Fix getSheet method to accept sheetId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [x.x.x] - Unreleased
+### Fixed
+- getSheet API returns 404 Not Found for existing sheet [#161](https://github.com/smartsheet/smartsheet-javascript-sdk/issues/161)
+
 ## [4.7.1] - 2026-02-12
 ### Added
 - WiremMock integration tests for contract testing for GET /2.0/users/{userId}/plans and GET /2.0/users endpoints

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ smartsheet.sheets.listSheets(options)
     const sheetId = result.data[0].id;  // Choose the first sheet
 
     // Load one sheet
-    smartsheet.sheets.getSheet({id: sheetId})
+    smartsheet.sheets.getSheet({sheetId: sheetId})
       .then(function(sheetInfo) {
         console.log(sheetInfo);
       })

--- a/lib/sheets/get.js
+++ b/lib/sheets/get.js
@@ -25,12 +25,18 @@ export function create(options) {
 
   const getSheetAsPDF = (getOptions, callback) => {
     const urlOptions = { url: buildUrl(getOptions.sheetId) };
-    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions, { accept: headers.applicationPdf, encoding: null }), callback);
+    return requestor.get(
+      _.extend({}, optionsToSend, urlOptions, getOptions, { accept: headers.applicationPdf, encoding: null }),
+      callback
+    );
   };
 
   const getSheetAsExcel = (getOptions, callback) => {
     const urlOptions = { url: buildUrl(getOptions.sheetId) };
-    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions, { accept: headers.vndMsExcel, encoding: null }), callback);
+    return requestor.get(
+      _.extend({}, optionsToSend, urlOptions, getOptions, { accept: headers.vndMsExcel, encoding: null }),
+      callback
+    );
   };
 
   const getSheetVersion = (getOptions, callback) => {

--- a/lib/sheets/get.js
+++ b/lib/sheets/get.js
@@ -5,24 +5,37 @@ export function create(options) {
   const requestor = options.requestor;
 
   const optionsToSend = {
-    url: options.apiUrls.sheets,
+    ...options.clientOptions,
   };
-  _.extend(optionsToSend, options.clientOptions);
 
-  const listSheets = (getOptions, callback) => requestor.get(_.extend({}, optionsToSend, getOptions), callback);
+  const listSheets = (getOptions, callback) => {
+    const urlOptions = { url: buildUrl() };
+    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
+  };
 
-  const getSheetAsCSV = (getOptions, callback) =>
-    listSheets(_.extend({}, getOptions, { accept: headers.textCsv }), callback);
+  const getSheet = (getOptions, callback) => {
+    const urlOptions = { url: buildUrl(getOptions.sheetId) };
+    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
+  };
 
-  const getSheetAsPDF = (getOptions, callback) =>
-    listSheets(_.extend({}, getOptions, { accept: headers.applicationPdf, encoding: null }), callback);
+  const getSheetAsCSV = (getOptions, callback) => {
+    const urlOptions = { url: buildUrl(getOptions.sheetId) };
+    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions, { accept: headers.textCsv }), callback);
+  };
 
-  const getSheetAsExcel = (getOptions, callback) =>
-    listSheets(_.extend({}, getOptions, { accept: headers.vndMsExcel, encoding: null }), callback);
+  const getSheetAsPDF = (getOptions, callback) => {
+    const urlOptions = { url: buildUrl(getOptions.sheetId) };
+    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions, { accept: headers.applicationPdf, encoding: null }), callback);
+  };
+
+  const getSheetAsExcel = (getOptions, callback) => {
+    const urlOptions = { url: buildUrl(getOptions.sheetId) };
+    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions, { accept: headers.vndMsExcel, encoding: null }), callback);
+  };
 
   const getSheetVersion = (getOptions, callback) => {
-    const urlOptions = { url: options.apiUrls.sheets + '/' + getOptions.sheetId + '/version' };
-    return listSheets(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
+    const urlOptions = { url: buildUrl(getOptions.sheetId) + '/version' };
+    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 
   const listOrganizationSheets = (getOptions, callback) => {
@@ -30,8 +43,15 @@ export function create(options) {
     return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 
+  const buildUrl = (sheetId) => {
+    if (sheetId !== undefined) {
+      return options.apiUrls.sheets + '/' + sheetId;
+    }
+    return options.apiUrls.sheets;
+  };
+
   return {
-    getSheet: listSheets, // will retrieve a single sheet when passed 'id' field
+    getSheet: getSheet,
     listSheets: listSheets,
     getSheetAsCSV: getSheetAsCSV,
     getSheetAsExcel: getSheetAsExcel,

--- a/test/functional/endpoints.spec.ts
+++ b/test/functional/endpoints.spec.ts
@@ -196,11 +196,11 @@ describe('Method Unit Tests', () => {
                 { name: 'addDiscussionComment', stub: 'post', options: {sheetId:123, discussionId: 234}, expectedRequest: {url: "sheets/123/discussions/234/comments"}},
                 { name: 'deleteDiscussion', stub: 'delete', options: {sheetId:123, discussionId: 234}, expectedRequest: {url: "sheets/123/discussions/234"}},
                 // get
-                { name: 'getSheet', stub: 'get', options: {}, expectedRequest: {url: "sheets"}},
+                { name: 'getSheet', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123"}},
                 { name: 'listSheets', stub: 'get', options: undefined, expectedRequest: {url: "sheets"}},
-                { name: 'getSheetAsCSV', stub: 'get', options: {}, expectedRequest: {url: "sheets", accept: constants.acceptHeaders.textCsv}},
-                { name: 'getSheetAsExcel', stub: 'get', options: {}, expectedRequest: {url: "sheets", accept: constants.acceptHeaders.vndMsExcel, encoding:null}},
-                { name: 'getSheetAsPDF', stub: 'get', options: {}, expectedRequest: {url: "sheets", accept: constants.acceptHeaders.applicationPdf, encoding:null}},
+                { name: 'getSheetAsCSV', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123", accept: constants.acceptHeaders.textCsv}},
+                { name: 'getSheetAsExcel', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123", accept: constants.acceptHeaders.vndMsExcel, encoding:null}},
+                { name: 'getSheetAsPDF', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123", accept: constants.acceptHeaders.applicationPdf, encoding:null}},
                 { name: 'getSheetVersion', stub: 'get', options: {sheetId: 123}, expectedRequest: {url: "sheets/123/version"}},
                 { name: 'listOrganizationSheets', stub: 'get', options: undefined, expectedRequest: {url: "users/sheets"}},
                 // summaries

--- a/test/functional/sheets.spec.ts
+++ b/test/functional/sheets.spec.ts
@@ -32,16 +32,16 @@ describe('Client Unit Tests', () => {
       'should not change base URL when getSheetVersion is called first',
       async () => {
         // First call to getSheet
-        await smartsheet.sheets.getSheet({ id: 100 });
-        expect(spyGet.mock.calls[0][0]).toHaveProperty('url', 'sheets');
+        await smartsheet.sheets.getSheet({ sheetId: 100 });
+        expect(spyGet.mock.calls[0][0]).toHaveProperty('url', 'sheets/100');
 
         // First call to getSheetVersion
         await smartsheet.sheets.getSheetVersion({ sheetId: 100 });
         expect(spyGet.mock.calls[1][0]).toHaveProperty('url', 'sheets/100/version');
 
         // Second call to getSheet
-        await smartsheet.sheets.getSheet({ id: 100 });
-        expect(spyGet.mock.calls[2][0]).toHaveProperty('url', 'sheets');
+        await smartsheet.sheets.getSheet({ sheetId: 100 });
+        expect(spyGet.mock.calls[2][0]).toHaveProperty('url', 'sheets/100');
       }
     );
 
@@ -49,16 +49,16 @@ describe('Client Unit Tests', () => {
       'should not change base URL when getOrganizationSheets is called first',
       async () => {
         // First call to getSheet
-        await smartsheet.sheets.getSheet({ id: 100 });
-        expect(spyGet.mock.calls[0][0]).toHaveProperty('url', 'sheets');
+        await smartsheet.sheets.getSheet({ sheetId: 100 });
+        expect(spyGet.mock.calls[0][0]).toHaveProperty('url', 'sheets/100');
 
         // First call to getSheetVersion
         await smartsheet.sheets.listOrganizationSheets();
         expect(spyGet.mock.calls[1][0]).toHaveProperty('url', 'users/sheets');
 
         // Second call to getSheet
-        await smartsheet.sheets.getSheet({ id: 100 });
-        expect(spyGet.mock.calls[2][0]).toHaveProperty('url', 'sheets');
+        await smartsheet.sheets.getSheet({ sheetId: 100 });
+        expect(spyGet.mock.calls[2][0]).toHaveProperty('url', 'sheets/100');
       }
     );
   });


### PR DESCRIPTION
## Fix `getSheet` URL and parameter (#161)

### Problem
`getSheet` does not take `sheetId` as the parameter name and routes to the `/sheets` collection URL instead of `/sheets/{sheetId}`.

### Changes
- **`lib/sheets/get.js`**
  - Added a dedicated `getSheet` function that builds the URL as `sheets/{sheetId}` using the new `buildUrl(sheetId)` helper.
  - Refactored `getSheetAsCSV`, `getSheetAsPDF`, and `getSheetAsExcel` to directly call the requestor with `sheetId`-based URLs instead of delegating to `listSheets`.
  - Replaced `_.extend(optionsToSend, ...)` (mutating shared state) with spread syntax to prevent URL bleed-through between calls.
- **`README.md`** — Updated example to use `sheetId` instead of `id`.
- **Tests** — Updated `endpoints.spec.ts` and `sheets.spec.ts` to reflect the corrected parameter name and expected URLs.