### PR TITLE
Add objectIdStr field to Event interface

### DIFF
--- a/lib/events/types.ts
+++ b/lib/events/types.ts
@@ -75,6 +75,11 @@ export interface Event {
   objectId: string;
 
   /**
+   * Alphanumeric object identifier for v2.0+ support.
+   */
+  objectIdStr?: string;
+
+  /**
    * Date and time of the event. Defaults to ISO-8601 format.
    * See dates and times for more information.
    */


### PR DESCRIPTION
## Summary
Adds the `objectIdStr` field to the Event interface to support alphanumeric object identifiers.


## Changes
- ✅ Added `objectIdStr?: string` field to Event interface
- ✅ Field is optional and backward compatible