### PR TITLE
Reports API Endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for DELETE /reports/{reportId}/scope endpoint
 - Support for DELETE /reports/{reportId} endpoint
 - Added support for POST /2.0/reports/{reportId}/columns endpoint
+- Added support for POST /2.0/reports endpoint (create report)
+- WireMock integration tests for contract testing for POST /2.0/reports endpoint
 
 ## [4.7.2] - 2026-03-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - WireMock integration tests for contract testing for POST /2.0/users/{userId}/plans/{planId}/upgrade and POST /2.0/users/{userId}/plans/{planId}/downgrade
 - WireMock integration tests for contract testing for DELETE /2.0/users/{userId}/plans/{planId} endpoint
 - Remove trailing slashes from routes
+- Support for POST /reports/{reportId}/scope endpoint
+- Support for DELETE /reports/{reportId}/scope endpoint
 ### Updated
 - listAllUsers url generation
 - Folder structure for the Users related WireMock tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for POST /reports/{reportId}/scope endpoint
 - Support for DELETE /reports/{reportId}/scope endpoint
 - Support for DELETE /reports/{reportId} endpoint
+- Added support for POST /2.0/reports/{reportId}/columns endpoint
 
 ## [4.7.2] - 2026-03-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Added support for PATCH /2.0/reports/{reportId}/definition endpoint
+- WireMock integration tests for contract testing for PATCH /2.0/reports/{reportId}/definition endpoint
+- Support for POST /reports/{reportId}/scope endpoint
+- Support for DELETE /reports/{reportId}/scope endpoint
+- Support for DELETE /reports/{reportId} endpoint
+
 ## [4.7.2] - 2026-03-17
 ### Fixed
 - App crashing after updating to v4.7.1 with logLevel set to 'info' [#158](https://github.com/smartsheet/smartsheet-javascript-sdk/issues/158)
@@ -16,8 +23,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - WireMock integration tests for contract testing for POST /2.0/users/{userId}/plans/{planId}/upgrade and POST /2.0/users/{userId}/plans/{planId}/downgrade
 - WireMock integration tests for contract testing for DELETE /2.0/users/{userId}/plans/{planId} endpoint
 - Remove trailing slashes from routes
-- Support for POST /reports/{reportId}/scope endpoint
-- Support for DELETE /reports/{reportId}/scope endpoint
 ### Updated
 - listAllUsers url generation
 - Folder structure for the Users related WireMock tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - WireMock integration tests for CONTRIBUTOR seat type filtering and responses
 - WireMock integration test for downgrading users to CONTRIBUTOR seat type
 - Comprehensive tests for `displayContributorSeatType` query parameter behavior
-
-### Fixed
-- `buildUrl` in [lib/utils/httpRequestor.js](lib/utils/httpRequestor.js) now accounts for the fact that `baseUrl` does not have a trailing slash.
-- Removed trailing slash from `getContact` to account for the fix above.
-
-### Added
 - Added support for PATCH /2.0/reports/{reportId}/definition endpoint
 - WireMock integration tests for contract testing for PATCH /2.0/reports/{reportId}/definition endpoint
 - Support for POST /reports/{reportId}/scope endpoint
@@ -26,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added support for POST /2.0/reports/{reportId}/columns endpoint
 - Added support for POST /2.0/reports endpoint (create report)
 - WireMock integration tests for contract testing for POST /2.0/reports endpoint
+
+### Fixed
+- `buildUrl` in [lib/utils/httpRequestor.js](lib/utils/httpRequestor.js) now accounts for the fact that `baseUrl` does not have a trailing slash.
+- Removed trailing slash from `getContact` to account for the fix above.
 
 ## [4.7.2] - 2026-03-17
 ### Fixed

--- a/lib/columns/types.ts
+++ b/lib/columns/types.ts
@@ -1,3 +1,5 @@
+import type { SystemColumnType } from '../reports/types';
+
 /**
  * Represents a column in a sheet.
  */
@@ -69,8 +71,15 @@ export interface Column {
 
   /**
    * System column type.
+   *
+   * Valid system column types:
+   * - AUTO_NUMBER (use with type: TEXT_NUMBER)
+   * - CREATED_BY (use with type: CONTACT_LIST)
+   * - CREATED_DATE (use with type: DATETIME)
+   * - MODIFIED_BY (use with type: CONTACT_LIST)
+   * - MODIFIED_DATE (use with type: DATETIME)
    */
-  systemColumnType: string;
+  systemColumnType: SystemColumnType | string;
 
   /**
    * Array of tags for the column.

--- a/lib/reports/index.ts
+++ b/lib/reports/index.ts
@@ -90,7 +90,7 @@ export function create(options: CreateOptions): ReportsApi {
   };
 
   const deleteReport = (deleteOptions: DeleteReportOptions, callback?: RequestCallback<DeleteReportResponse>) => {
-    const urlOptions = { url: options.apiUrls.reports + '/delete/' + deleteOptions.reportId };
+    const urlOptions = { url: options.apiUrls.reports + '/' + deleteOptions.reportId };
     return requestor.delete({ ...optionsToSend, ...urlOptions, ...deleteOptions }, callback);
   };
 

--- a/lib/reports/index.ts
+++ b/lib/reports/index.ts
@@ -22,6 +22,8 @@ import type {
   DeleteReportResponse,
   AddReportScopeOptions,
   RemoveReportScopeOptions,
+  AddReportColumnsOptions,
+  AddReportColumnsResponse,
 } from './types';
 import * as constants from '../utils/constants';
 
@@ -124,6 +126,14 @@ export function create(options: CreateOptions): ReportsApi {
     return requestor.delete({ ...optionsToSend, ...urlOptions, ...deleteOptions }, callback);
   };
 
+  const addReportColumns = (
+    postOptions: AddReportColumnsOptions,
+    callback?: RequestCallback<AddReportColumnsResponse>
+  ): Promise<AddReportColumnsResponse> => {
+    const urlOptions = { url: options.apiUrls.reports + '/' + postOptions.reportId + '/columns' };
+    return requestor.post({ ...optionsToSend, ...urlOptions, ...postOptions }, callback);
+  };
+
   return {
     listReports,
     getReport,
@@ -136,6 +146,7 @@ export function create(options: CreateOptions): ReportsApi {
     deleteReport,
     addReportScope,
     removeReportScope,
+    addReportColumns,
     ...shares.create(options),
   };
 }

--- a/lib/reports/index.ts
+++ b/lib/reports/index.ts
@@ -17,6 +17,7 @@ import type {
   ReportPublish,
   SetReportPublishStatusOptions,
   SetReportPublishStatusResponse,
+  UpdateReportDefinitionOptions,
   DeleteReportOptions,
   DeleteReportResponse,
   AddReportScopeOptions,
@@ -92,6 +93,16 @@ export function create(options: CreateOptions): ReportsApi {
     return requestor.put({ ...optionsToSend, ...urlOptions, ...putOptions }, callback);
   };
 
+  const updateReportDefinition = (
+    putOptions: UpdateReportDefinitionOptions,
+    callback?: RequestCallback<BaseResponseStatus>
+  ): Promise<BaseResponseStatus> => {
+    const urlOptions = {
+      url: options.apiUrls.reports + '/' + putOptions.reportId + '/definition',
+    };
+    return requestor.put({ ...optionsToSend, ...urlOptions, ...putOptions }, callback);
+  };
+
   const deleteReport = (deleteOptions: DeleteReportOptions, callback?: RequestCallback<DeleteReportResponse>) => {
     const urlOptions = { url: options.apiUrls.reports + '/' + deleteOptions.reportId };
     return requestor.delete({ ...optionsToSend, ...urlOptions, ...deleteOptions }, callback);
@@ -121,6 +132,7 @@ export function create(options: CreateOptions): ReportsApi {
     getReportAsCSV,
     getReportPublishStatus,
     setReportPublishStatus,
+    updateReportDefinition,
     deleteReport,
     addReportScope,
     removeReportScope,

--- a/lib/reports/index.ts
+++ b/lib/reports/index.ts
@@ -102,6 +102,7 @@ export function create(options: CreateOptions): ReportsApi {
     getReportAsCSV,
     getReportPublishStatus,
     setReportPublishStatus,
+    deleteReport,
     ...shares.create(options),
   };
 }

--- a/lib/reports/index.ts
+++ b/lib/reports/index.ts
@@ -1,4 +1,5 @@
 import shareModule from '../share/share';
+import type { BaseResponseStatus } from '../types/BaseResponseStatus';
 import type { CreateOptions } from '../types/CreateOptions';
 import type { RequestCallback } from '../types/RequestCallback';
 import type { RequestOptions } from '../types/RequestOptions';
@@ -16,6 +17,8 @@ import type {
   ReportPublish,
   SetReportPublishStatusOptions,
   SetReportPublishStatusResponse,
+  AddReportScopeOptions,
+  RemoveReportScopeOptions,
 } from './types';
 import * as constants from '../utils/constants';
 
@@ -87,6 +90,22 @@ export function create(options: CreateOptions): ReportsApi {
     return requestor.put({ ...optionsToSend, ...urlOptions, ...putOptions }, callback);
   };
 
+  const addReportScope = (
+    postOptions: AddReportScopeOptions,
+    callback?: RequestCallback<BaseResponseStatus>
+  ): Promise<BaseResponseStatus> => {
+    const urlOptions = { url: options.apiUrls.reports + '/' + postOptions.reportId + '/scope' };
+    return requestor.post({ ...optionsToSend, ...urlOptions, ...postOptions }, callback);
+  };
+
+  const removeReportScope = (
+    deleteOptions: RemoveReportScopeOptions,
+    callback?: RequestCallback<BaseResponseStatus>
+  ): Promise<BaseResponseStatus> => {
+    const urlOptions = { url: options.apiUrls.reports + '/' + deleteOptions.reportId + '/scope' };
+    return requestor.delete({ ...optionsToSend, ...urlOptions, ...deleteOptions }, callback);
+  };
+
   return {
     listReports,
     getReport,
@@ -95,6 +114,8 @@ export function create(options: CreateOptions): ReportsApi {
     getReportAsCSV,
     getReportPublishStatus,
     setReportPublishStatus,
+    addReportScope,
+    removeReportScope,
     ...shares.create(options),
   };
 }

--- a/lib/reports/index.ts
+++ b/lib/reports/index.ts
@@ -24,6 +24,8 @@ import type {
   RemoveReportScopeOptions,
   AddReportColumnsOptions,
   AddReportColumnsResponse,
+  CreateReportOptions,
+  CreateReportResponse,
 } from './types';
 import * as constants from '../utils/constants';
 
@@ -134,6 +136,14 @@ export function create(options: CreateOptions): ReportsApi {
     return requestor.post({ ...optionsToSend, ...urlOptions, ...postOptions }, callback);
   };
 
+  const createReport = (
+    postOptions: CreateReportOptions,
+    callback?: RequestCallback<CreateReportResponse>
+  ): Promise<CreateReportResponse> => {
+    const urlOptions = { url: options.apiUrls.reports };
+    return requestor.post({ ...optionsToSend, ...urlOptions, ...postOptions }, callback);
+  };
+
   return {
     listReports,
     getReport,
@@ -147,6 +157,7 @@ export function create(options: CreateOptions): ReportsApi {
     addReportScope,
     removeReportScope,
     addReportColumns,
+    createReport,
     ...shares.create(options),
   };
 }

--- a/lib/reports/index.ts
+++ b/lib/reports/index.ts
@@ -16,6 +16,8 @@ import type {
   ReportPublish,
   SetReportPublishStatusOptions,
   SetReportPublishStatusResponse,
+  DeleteReportOptions,
+  DeleteReportResponse,
 } from './types';
 import * as constants from '../utils/constants';
 
@@ -85,6 +87,11 @@ export function create(options: CreateOptions): ReportsApi {
   ): Promise<SetReportPublishStatusResponse> => {
     const urlOptions = { url: options.apiUrls.reports + '/' + putOptions.reportId + '/publish' };
     return requestor.put({ ...optionsToSend, ...urlOptions, ...putOptions }, callback);
+  };
+
+  const deleteReport = (deleteOptions: DeleteReportOptions, callback?: RequestCallback<DeleteReportResponse>) => {
+    const urlOptions = { url: options.apiUrls.reports + '/delete/' + deleteOptions.reportId };
+    return requestor.delete({ ...optionsToSend, ...urlOptions, ...deleteOptions }, callback);
   };
 
   return {

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -1050,11 +1050,11 @@ export enum ReportColumnType {
 }
 
 /**
- * System column types for report columns and column identifiers.
+ * System column types for columns, report columns, and column identifiers.
  *
- * Used by {@link ReportColumn} and {@link ReportColumnIdentifier}.
+ * Used by {@link Column}, {@link ReportColumn}, and {@link ReportColumnIdentifier}.
  */
-export enum ReportSystemColumnType {
+export enum SystemColumnType {
   CREATED_BY = 'CREATED_BY',
   CREATED_DATE = 'CREATED_DATE',
   MODIFIED_BY = 'MODIFIED_BY',
@@ -1295,7 +1295,7 @@ export interface ReportColumnIdentifier {
   /**
    * System column type to match. See [System Columns](/api/smartsheet/openapi/columns).
    */
-  systemColumnType?: ReportSystemColumnType | string;
+  systemColumnType?: SystemColumnType | string;
   /**
    * Set this to `true` to match the primary column. When `true`, `type` and `systemColumnType` are not required.
    */
@@ -1420,7 +1420,7 @@ export interface ReportColumn {
    *
    * Must be used in combination with `type`. See valid combinations above.
    */
-  systemColumnType?: ReportSystemColumnType | string;
+  systemColumnType?: SystemColumnType | string;
   /**
    * Set to `true` to match the primary column. When `true`, `type` and `systemColumnType` are not required.
    */

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -722,3 +722,16 @@ export interface SetReportPublishStatusResponse extends BaseResponseStatus {
   failedItems?: FailedItem[];
   result: ReportPublish;
 }
+
+// ============================================================================
+// Delete Report
+// ============================================================================
+
+export interface DeleteReportOptions extends RequestOptions<undefined, undefined> {
+  /**
+   * Report Id
+   */
+  reportId: number;
+}
+
+export type DeleteReportResponse = BaseResponseStatus;

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -373,6 +373,63 @@ export interface ReportsApi {
     options: AddReportColumnsOptions,
     callback?: RequestCallback<AddReportColumnsResponse>
   ) => Promise<AddReportColumnsResponse>;
+
+  /**
+   * Create a new report by specifying name, destination, scope, columns and definition.
+   *
+   * This operation creates a new report with specified columns, scope (sheets/workspaces),
+   * and optional filters, grouping, and sorting.
+   *
+   * @param options - {@link CreateReportOptions} - Configuration options for the request
+   * @param callback - {@link RequestCallback}\<{@link CreateReportResponse}\> - Optional callback function
+   * @returns Promise\<{@link CreateReportResponse}\>
+   *
+   * @remarks
+   * **Who can use this operation:**
+   * - **Permissions:** READ_SHEETS OAuth2 scope or API Token authentication
+   *
+   * **Additional notes:**
+   * - Report name must be 1-50 characters
+   * - Minimum 1 column required, maximum 400 columns
+   * - Minimum 1 scope item required, maximum 100 scope items
+   * - Destination must be a folder or workspace
+   *
+   * It mirrors to the following Smartsheet REST API method: `POST /reports`
+   *
+   * @example
+   * ```typescript
+   * const result = await client.reports.createReport({
+   *   body: {
+   *     name: 'Q2 Project Status',
+   *     destination: {
+   *       destinationType: 'folder',
+   *       destinationId: 1234567890
+   *     },
+   *     columns: [
+   *       { title: 'Task Name', type: 'TEXT_NUMBER', primary: true, index: 0 },
+   *       { title: 'Status', type: 'PICKLIST', index: 1 }
+   *     ],
+   *     scope: [
+   *       { assetType: 'SHEET', assetId: 9876543210 }
+   *     ],
+   *     reportDefinition: {
+   *       filters: {
+   *         operator: 'AND',
+   *         criteria: [{
+   *           column: { title: 'Status', type: 'PICKLIST' },
+   *           operator: 'EQUAL',
+   *           values: ['In Progress']
+   *         }]
+   *       }
+   *     }
+   *   }
+   * });
+   * ```
+   */
+  createReport: (
+    options: CreateReportOptions,
+    callback?: RequestCallback<CreateReportResponse>
+  ) => Promise<CreateReportResponse>;
 }
 
 // ============================================================================
@@ -1476,4 +1533,105 @@ export interface AddReportColumnsResponse extends BaseResponseStatus {
    * Array of report columns that were added.
    */
   result: ReportColumn[];
+}
+
+// ============================================================================
+// Create Report
+// ============================================================================
+
+/**
+ * Type of destination container for create operations.
+ */
+export enum ReportDestinationType {
+  FOLDER = 'folder',
+  WORKSPACE = 'workspace',
+}
+
+/**
+ * Container destination for creating a report.
+ */
+export interface ReportDestination {
+  /**
+   * The ID of the destination container (folder or workspace).
+   */
+  destinationId: number;
+  /**
+   * Type of destination container.
+   */
+  destinationType: ReportDestinationType | string;
+}
+
+/**
+ * Request body for creating a report.
+ */
+export interface CreateReportBody {
+  /**
+   * Report name (1-50 characters).
+   */
+  name: string;
+  /**
+   * Array of report columns (1-400 items).
+   */
+  columns: ReportColumn[];
+  /**
+   * Array of scope items (sheets and/or workspaces) (1-100 items).
+   */
+  scope: ReportScopeAsset[];
+  /**
+   * Report definition containing filters, grouping, and sorting.
+   */
+  reportDefinition?: ReportDefinition;
+  /**
+   * If true, the report is a sheet summary report; otherwise it is a row report.
+   */
+  isSummaryReport?: boolean;
+  /**
+   * Destination container for the report.
+   */
+  destination: ReportDestination;
+}
+
+/**
+ * Result from creating a report.
+ */
+export interface CreateReportResult {
+  /**
+   * The report's unique identifier.
+   */
+  id: number;
+  /**
+   * The report's name.
+   */
+  name: string;
+  /**
+   * User's access level to the report.
+   */
+  accessLevel: string;
+  /**
+   * URL to the report in Smartsheet.
+   */
+  permalink: string;
+  /**
+   * If true, the report is a sheet summary report; otherwise it is a row report.
+   */
+  isSummaryReport: boolean;
+}
+
+/**
+ * Options for creating a report.
+ */
+export type CreateReportOptions = RequestOptions<undefined, CreateReportBody>;
+
+/**
+ * Response from creating a report.
+ */
+export interface CreateReportResponse extends BaseResponseStatus {
+  /**
+   * Array of BulkItemFailure objects which represents the items that failed to be added or updated.
+   */
+  failedItems?: FailedItem[];
+  /**
+   * Array containing the created report details.
+   */
+  result: CreateReportResult[];
 }

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -188,7 +188,7 @@ export interface ReportsApi {
    *
    * @remarks
    * **Who can use this operation:**
-   * - **Permissions:** EDITOR or ADMIN access to the report
+   * - **Permissions:** ADMIN or OWNER access to the report
    *
    * **Additional notes:**
    * - Maximum of 100 scope items can be added at once
@@ -225,7 +225,7 @@ export interface ReportsApi {
    *
    * @remarks
    * **Who can use this operation:**
-   * - **Permissions:** EDITOR or ADMIN access to the report
+   * - **Permissions:** ADMIN or OWNER access to the report
    *
    * **Additional notes:**
    * - Maximum of 100 scope items can be removed at once

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -721,8 +721,8 @@ Only returned in a response if readOnlyFullEnabled = true.
  * Asset types that can be included in a report's scope.
  */
 export enum ReportAssetType {
-  SHEET = 'SHEET',
-  WORKSPACE = 'WORKSPACE',
+  SHEET = 'sheet',
+  WORKSPACE = 'workspace',
 }
 
 /**

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -175,6 +175,28 @@ export interface ReportsApi {
     options: SetReportPublishStatusOptions,
     callback?: RequestCallback<SetReportPublishStatusResponse>
   ) => Promise<SetReportPublishStatusResponse>;
+
+  /**
+   * Deletes the specified Report.
+   * 
+   * @param options - {@link DeleteReportOptions} - Configuration options for the request
+   * @param callback - {@link RequestCallback}\<{@link DeleteReportResponse}\> - Optional callback function
+   * @returns Promise\<{@link DeleteReportResponse}\>
+   * 
+   * @remarks
+   * It mirrors to the following Smartsheet REST API method: `DELETE /2.0/reports/{reportId}`
+   * 
+   * @example
+   * ```typescript
+   * const result = await client.reports.deleteReport({
+   *   reportId: 11235813
+   * });
+   * ```
+   */
+  deleteReport: (
+    options: DeleteReportOptions,
+    callback?: RequestCallback<DeleteReportResponse>
+  ) => Promise<DeleteReportResponse>;
 }
 
 // ============================================================================

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -197,7 +197,7 @@ export interface ReportsApi {
     options: DeleteReportOptions,
     callback?: RequestCallback<DeleteReportResponse>
   ) => Promise<DeleteReportResponse>;
-  
+
   /**
    * Add sheets and/or workspaces to a report's scope.
    *

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -1614,7 +1614,11 @@ export interface CreateReportResult {
   /**
    * If true, the report is a sheet summary report; otherwise it is a row report.
    */
-  isSummaryReport: boolean;
+  isSummaryReport?: boolean;
+  /**
+   * Array of report columns. Only included in the response when columns are created with the report.
+   */
+  columns?: ReportColumn[];
 }
 
 /**
@@ -1631,7 +1635,7 @@ export interface CreateReportResponse extends BaseResponseStatus {
    */
   failedItems?: FailedItem[];
   /**
-   * Array containing the created report details.
+   * The created report details.
    */
-  result: CreateReportResult[];
+  result: CreateReportResult;
 }

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -177,6 +177,62 @@ export interface ReportsApi {
   ) => Promise<SetReportPublishStatusResponse>;
 
   /**
+   * Update a Report's definition based on the specified ID
+   *
+   * **Note:** This endpoint supports partial updates **only on root level** properties of the report definition,
+   * such as `filters`, `groupingCriteria` and `summarizingCriteria`. For example, you can update the report's filters
+   * without affecting its grouping criteria. However, nested properties within these objects,
+   * such as a specific filter or grouping criterion, cannot be updated individually and
+   * require a full replacement of the respective section.
+   *
+   * @param options - {@link UpdateReportDefinitionOptions} - Configuration options for the request
+   * @param callback - {@link RequestCallback}\<{@link BaseResponseStatus}\> - Optional callback function
+   * @returns Promise\<{@link BaseResponseStatus}\>
+   *
+   * @remarks
+   * It mirrors to the following Smartsheet REST API method: `PUT /reports/{reportId}/definition`
+   *
+   * @example
+   * ```typescript
+   * // Update report filters with different value types
+   * const result = await client.reports.updateReportDefinition({
+   *   reportId: 4583173393803140,
+   *   body: {
+   *     filters: {
+   *       operator: 'AND',
+   *       criteria: [
+   *         {
+   *           column: { title: 'Status', type: 'PICKLIST' },
+   *           operator: 'EQUAL',
+   *           values: ['Complete']  // String values
+   *         },
+   *         {
+   *           column: { title: 'Priority', type: 'TEXT_NUMBER' },
+   *           operator: 'GREATER_THAN',
+   *           values: [5]  // Numeric values
+   *         },
+   *         {
+   *           column: { title: 'Due Date', type: 'DATE' },
+   *           operator: 'GREATER_THAN',
+   *           values: [{ objectType: 'DATE', value: '2024-01-01' }]  // Date object
+   *         },
+   *         {
+   *           column: { title: 'Assigned To', type: 'CONTACT_LIST' },
+   *           operator: 'EQUAL',
+   *           values: [{ objectType: 'CURRENT_USER', value: '' }]  // Current user filter
+   *         }
+   *       ]
+   *     }
+   *   }
+   * });
+   * ```
+   */
+  updateReportDefinition: (
+    options: UpdateReportDefinitionOptions,
+    callback?: RequestCallback<BaseResponseStatus>
+  ) => Promise<BaseResponseStatus>;
+
+  /**
    * Deletes the specified Report.
    *
    * @param options - {@link DeleteReportOptions} - Configuration options for the request
@@ -843,6 +899,363 @@ export interface SetReportPublishStatusResponse extends BaseResponseStatus {
 }
 
 // ============================================================================
+// Update Report Definition
+// ============================================================================
+
+export interface UpdateReportDefinitionOptions extends RequestOptions<undefined, ReportDefinition> {
+  /**
+   * reportID of the report being accessed.
+   */
+  reportId: number;
+}
+
+// ============================================================================
+// Report Definition Enums
+// ============================================================================
+
+/**
+ * Boolean operator for filter expressions.
+ */
+export enum ReportFilterOperator {
+  AND = 'AND',
+  OR = 'OR',
+}
+
+/**
+ * Filter condition operators.
+ */
+export enum ReportFilterConditionOperator {
+  EQUAL = 'EQUAL',
+  NOT_EQUAL = 'NOT_EQUAL',
+  GREATER_THAN = 'GREATER_THAN',
+  LESS_THAN = 'LESS_THAN',
+  CONTAINS = 'CONTAINS',
+  BETWEEN = 'BETWEEN',
+  TODAY = 'TODAY',
+  PAST = 'PAST',
+  FUTURE = 'FUTURE',
+  LAST_N_DAYS = 'LAST_N_DAYS',
+  NEXT_N_DAYS = 'NEXT_N_DAYS',
+  IS_BLANK = 'IS_BLANK',
+  IS_NOT_BLANK = 'IS_NOT_BLANK',
+  IS_NUMBER = 'IS_NUMBER',
+  IS_NOT_NUMBER = 'IS_NOT_NUMBER',
+  IS_DATE = 'IS_DATE',
+  IS_NOT_DATE = 'IS_NOT_DATE',
+  IS_CHECKED = 'IS_CHECKED',
+  IS_UNCHECKED = 'IS_UNCHECKED',
+  IS_ONE_OF = 'IS_ONE_OF',
+  IS_NOT_ONE_OF = 'IS_NOT_ONE_OF',
+  LESS_THAN_OR_EQUAL = 'LESS_THAN_OR_EQUAL',
+  GREATER_THAN_OR_EQUAL = 'GREATER_THAN_OR_EQUAL',
+  DOES_NOT_CONTAIN = 'DOES_NOT_CONTAIN',
+  NOT_BETWEEN = 'NOT_BETWEEN',
+  NOT_TODAY = 'NOT_TODAY',
+  NOT_PAST = 'NOT_PAST',
+  NOT_FUTURE = 'NOT_FUTURE',
+  NOT_LAST_N_DAYS = 'NOT_LAST_N_DAYS',
+  NOT_NEXT_N_DAYS = 'NOT_NEXT_N_DAYS',
+  HAS_ANY_OF = 'HAS_ANY_OF',
+  HAS_NONE_OF = 'HAS_NONE_OF',
+  HAS_ALL_OF = 'HAS_ALL_OF',
+  NOT_ALL_OF = 'NOT_ALL_OF',
+  MULTI_IS_EQUAL = 'MULTI_IS_EQUAL',
+  MULTI_IS_NOT_EQUAL = 'MULTI_IS_NOT_EQUAL',
+}
+
+/**
+ * Sorting direction for grouping and sorting criteria.
+ */
+export enum ReportSortingDirection {
+  ASCENDING = 'ASCENDING',
+  DESCENDING = 'DESCENDING',
+}
+
+/**
+ * Aggregation types for report summarizing criteria.
+ */
+export enum ReportAggregationType {
+  SUM = 'SUM',
+  AVG = 'AVG',
+  MIN = 'MIN',
+  MAX = 'MAX',
+  COUNT = 'COUNT',
+  FIRST = 'FIRST',
+  LAST = 'LAST',
+}
+
+/**
+ * Column types for report column identifiers.
+ */
+export enum ReportColumnType {
+  CHECKBOX = 'CHECKBOX',
+  DATE = 'DATE',
+  DATETIME = 'DATETIME',
+  DURATION = 'DURATION',
+  CONTACT_LIST = 'CONTACT_LIST',
+  MULTI_CONTACT_LIST = 'MULTI_CONTACT_LIST',
+  PICKLIST = 'PICKLIST',
+  MULTI_PICKLIST = 'MULTI_PICKLIST',
+  PREDECESSOR = 'PREDECESSOR',
+  TEXT_NUMBER = 'TEXT_NUMBER',
+}
+
+/**
+ * System column types for report column identifiers.
+ */
+export enum ReportSystemColumnType {
+  CREATED_BY = 'CREATED_BY',
+  CREATED_DATE = 'CREATED_DATE',
+  MODIFIED_BY = 'MODIFIED_BY',
+  MODIFIED_DATE = 'MODIFIED_DATE',
+  AUTO_NUMBER = 'AUTO_NUMBER',
+}
+
+// ============================================================================
+// Report Definition Types
+// ============================================================================
+
+/**
+ * The report definition contains filters, grouping and sorting properties of the report.
+ *
+ * Note: When groupingCriteria is defined the primary column of the report will move to the index 0 when it is first rendered by the app.
+ */
+export interface ReportDefinition {
+  /**
+   * Report filter expression.
+   */
+  filters?: ReportFilterExpression;
+  /**
+   * List of report grouping criteria.
+   */
+  groupingCriteria?: ReportGroupingCriterion[];
+  /**
+   * List of report summarizing criteria.
+   */
+  summarizingCriteria?: ReportSummarizingCriterion[];
+  /**
+   * List of report sorting criteria.
+   */
+  sortingCriteria?: ReportSortingCriterion[];
+}
+
+/**
+ * An expression to filter on report columns. It is a recursive object that allows at most three levels.
+ *
+ * It must include `operator` and at least one of the following: `criteria` or `nestedCriteria`
+ *
+ * Here is a two-level example with different value types:
+ *
+ * ```json
+ * {
+ *   "operator": "OR",
+ *   "nestedCriteria": [
+ *     {
+ *       "operator": "AND",
+ *       "criteria": [
+ *         {
+ *           "column": { "title": "Price", "type": "TEXT_NUMBER" },
+ *           "operator": "GREATER_THAN",
+ *           "values": [100]
+ *         },
+ *         {
+ *           "column": { "primary": true },
+ *           "operator": "CONTAINS",
+ *           "values": ["PROJ-1"]
+ *         }
+ *       ]
+ *     },
+ *     {
+ *       "operator": "AND",
+ *       "criteria": [
+ *         {
+ *           "column": { "title": "Due Date", "type": "DATE" },
+ *           "operator": "GREATER_THAN",
+ *           "values": [{ "objectType": "DATE", "value": "2024-01-01" }]
+ *         },
+ *         {
+ *           "column": { "title": "Assigned To", "type": "CONTACT_LIST" },
+ *           "operator": "EQUAL",
+ *           "values": [{ "objectType": "CURRENT_USER", "value": "" }]
+ *         }
+ *       ]
+ *     }
+ *   ]
+ * }
+ * ```
+ *
+ * It's equivalent to the following pseudo logic:
+ *
+ * ```
+ * (Price > 100 AND Primary CONTAINS "PROJ-1")
+ * OR
+ * (Due Date > 2024-01-01 AND Assigned To = CURRENT_USER)
+ * ```
+ */
+export interface ReportFilterExpression {
+  /**
+   * The boolean operator to apply to the list of `criteria` and `nestedCriteria`.
+   */
+  operator: ReportFilterOperator | string;
+  /**
+   * A recursive list of report filter expressions. Each item is joined to the filter expression with the AND/OR operator defined on this level.
+   */
+  nestedCriteria?: ReportFilterExpression[];
+  /**
+   * Criteria objects specifying custom criteria against which to match cell values. Each item is joined to the filter expression with the AND/OR operator defined on this level.
+   */
+  criteria?: ReportFilterCriterion[];
+}
+
+/**
+ * Represents a filter value object for special filter types.
+ * Used for date-based filters and current user filters.
+ */
+export interface ReportFilterObjectValue {
+  /**
+   * Type of the object value.
+   * - `DATE`: For date-based filter values
+   * - `CURRENT_USER`: For filtering by the current user
+   */
+  objectType: 'DATE' | 'CURRENT_USER';
+  /**
+   * The value associated with the object type.
+   * For DATE objects, this would be a date string.
+   * For CURRENT_USER, this represents the user identifier.
+   */
+  value: string;
+}
+
+/**
+ * Union type for report filter values.
+ * Can be a string, number, null, or a filter value object.
+ */
+export type ReportFilterValue = string | number | null | ReportFilterObjectValue;
+
+/**
+ * Represents a report filter criterion.
+ */
+export interface ReportFilterCriterion {
+  /**
+   * Object used to match a sheet column for a report.
+   */
+  column: ReportColumnIdentifier;
+  /**
+   * Condition operator.
+   */
+  operator: ReportFilterConditionOperator | string;
+  /**
+   * List of filter values.
+   *
+   * Values can be:
+   * - `string`: Regular text values (nullable)
+   * - `number`: Numeric values
+   * - `null`: Explicit null values
+   * - `ReportFilterObjectValue`: Special object values for dates or current user
+   *
+   * @example
+   * ```typescript
+   * // String values
+   * values: ["Complete", "In Progress"]
+   *
+   * // Numeric values
+   * values: [100, 200]
+   *
+   * // Date object values
+   * values: [{ objectType: "DATE", value: "2024-01-01" }]
+   *
+   * // Current user filter
+   * values: [{ objectType: "CURRENT_USER", value: "" }]
+   * ```
+   */
+  values?: (string | number | ReportFilterValue | undefined)[];
+}
+
+/**
+ * Report grouping criterion.
+ */
+export interface ReportGroupingCriterion {
+  /**
+   * Object used to match a sheet column for a report.
+   */
+  column: ReportColumnIdentifier;
+  /**
+   * Sorting direction within the group.
+   */
+  sortingDirection: ReportSortingDirection | string;
+  /**
+   * Indicates whether the group is expanded in the UI.
+   */
+  isExpanded?: boolean;
+}
+
+/**
+ * Report summarizing criterion.
+ */
+export interface ReportSummarizingCriterion {
+  /**
+   * Object used to match a sheet column for a report.
+   */
+  column: ReportColumnIdentifier;
+  /**
+   * Type of aggregation.
+   */
+  aggregationType: ReportAggregationType | string;
+}
+
+/**
+ * Report sorting criterion.
+ */
+export interface ReportSortingCriterion {
+  /**
+   * Object used to match a sheet column for a report.
+   */
+  column: ReportColumnIdentifier;
+  /**
+   * Sorting direction.
+   */
+  sortingDirection: ReportSortingDirection | string;
+}
+
+/**
+ * An object for matching a source sheet column for a report.
+ *
+ * **Column Matching Options:**
+ * - **Regular columns**: Specify `type` to match columns by type (optionally with `title` for additional matching).
+ * - **System columns**: Specify both `type` and `systemColumnType` to match system columns (e.g., Created By, Modified Date).
+ * - **Sheet name column**: Specify `type: TEXT_NUMBER` and `sheetNameColumn: true` to match the special "Sheet Name" column.
+ * - **Primary column**: Specify `primary: true` to match the primary column. When matching primary columns, `title` can be used to customize the primary column name in the rendered report.
+ *
+ * **Note:** Columns in the report are matched by the combination of `title` and `type` (and `systemColumnType` or `sheetNameColumn` if specified).
+ *
+ * **Note:** `symbol` is not used for matching and as a result `CHECKBOX` or `PICKLIST` columns with different symbols (from different sheets) can be combined into the same column in the report. You cannot combine `CHECKBOX` with `PICKLIST` into the same column in the report because they are different types.
+ */
+export interface ReportColumnIdentifier {
+  /**
+   * Column title to be matched from the source sheets.
+   *
+   * **Note:** If `primary` is **true** then this property can be used to customize the primary column title.
+   */
+  title?: string;
+  /**
+   * Type of column to match. See [Column Types](/api/smartsheet/openapi/columns).
+   */
+  type: ReportColumnType | string;
+  /**
+   * System column type to match. See [System Columns](/api/smartsheet/openapi/columns).
+   */
+  systemColumnType?: ReportSystemColumnType | string;
+  /**
+   * Set this to `true` to match the primary column. When `true`, `type` and `systemColumnType` are not required.
+   */
+  primary?: boolean;
+  /**
+   * Set this to `true` to match the special "Sheet Name" report column. Must be used with `type: TEXT_NUMBER`.
+   */
+  sheetNameColumn?: boolean;
+}
+
+// ============================================================================
 // Delete Report
 // ============================================================================
 
@@ -852,6 +1265,8 @@ export interface DeleteReportOptions extends RequestOptions<undefined, undefined
    */
   reportId: number;
 }
+
+export type DeleteReportResponse = BaseResponseStatus;
 
 // ============================================================================
 // Add Report Scope
@@ -867,7 +1282,6 @@ export interface AddReportScopeOptions extends RequestOptions<never, ReportScope
   reportId: number;
 }
 
-export type DeleteReportResponse = BaseResponseStatus;
 // ============================================================================
 // Remove Report Scope
 // ============================================================================

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -175,6 +175,79 @@ export interface ReportsApi {
     options: SetReportPublishStatusOptions,
     callback?: RequestCallback<SetReportPublishStatusResponse>
   ) => Promise<SetReportPublishStatusResponse>;
+
+  /**
+   * Add sheets and/or workspaces to a report's scope.
+   *
+   * This operation allows you to expand the data sources included in a report by adding
+   * sheets or workspaces. The report will then include data from these newly added sources.
+   *
+   * @param options - {@link AddReportScopeOptions} - Configuration options for the request
+   * @param callback - {@link RequestCallback}\<{@link BaseResponseStatus}\> - Optional callback function
+   * @returns Promise\<{@link BaseResponseStatus}\>
+   *
+   * @remarks
+   * **Who can use this operation:**
+   * - **Permissions:** EDITOR or ADMIN access to the report
+   *
+   * **Additional notes:**
+   * - Maximum of 100 scope items can be added at once
+   * - Requires READ_SHEETS OAuth2 scope or API Token authentication
+   *
+   * It mirrors to the following Smartsheet REST API method: `POST /reports/{reportId}/scope`
+   *
+   * @example
+   * ```typescript
+   * const result = await client.reports.addReportScope({
+   *   reportId: 1234567890,
+   *   body: [
+   *     { assetType: 'SHEET', assetId: 9876543210 },
+   *     { assetType: 'WORKSPACE', assetId: 1122334455 }
+   *   ]
+   * });
+   * console.log(result.message); // 'SUCCESS'
+   * ```
+   */
+  addReportScope: (
+    options: AddReportScopeOptions,
+    callback?: RequestCallback<BaseResponseStatus>
+  ) => Promise<BaseResponseStatus>;
+
+  /**
+   * Remove sheets and/or workspaces from a report's scope.
+   *
+   * This operation allows you to remove data sources from a report. The report will
+   * no longer include data from these removed sources.
+   *
+   * @param options - {@link RemoveReportScopeOptions} - Configuration options for the request
+   * @param callback - {@link RequestCallback}\<{@link BaseResponseStatus}\> - Optional callback function
+   * @returns Promise\<{@link BaseResponseStatus}\>
+   *
+   * @remarks
+   * **Who can use this operation:**
+   * - **Permissions:** EDITOR or ADMIN access to the report
+   *
+   * **Additional notes:**
+   * - Maximum of 100 scope items can be removed at once
+   * - Requires READ_SHEETS OAuth2 scope or API Token authentication
+   *
+   * It mirrors to the following Smartsheet REST API method: `DELETE /reports/{reportId}/scope`
+   *
+   * @example
+   * ```typescript
+   * const result = await client.reports.removeReportScope({
+   *   reportId: 1234567890,
+   *   body: [
+   *     { assetType: 'SHEET', assetId: 9876543210 }
+   *   ]
+   * });
+   * console.log(result.message); // 'SUCCESS'
+   * ```
+   */
+  removeReportScope: (
+    options: RemoveReportScopeOptions,
+    callback?: RequestCallback<BaseResponseStatus>
+  ) => Promise<BaseResponseStatus>;
 }
 
 // ============================================================================
@@ -519,6 +592,30 @@ Only returned in a response if readOnlyFullEnabled = true.
   readOnlyFullShowToolbar?: boolean;
 }
 
+/**
+ * Asset types that can be included in a report's scope.
+ */
+export enum ReportAssetType {
+  SHEET = 'SHEET',
+  WORKSPACE = 'WORKSPACE',
+}
+
+/**
+ * Represents an asset (sheet or workspace) in a report's scope.
+ */
+export interface ReportScopeAsset {
+  /**
+   * The asset type to be included in the scope of the report.
+   * @see ReportAssetType
+   */
+  assetType: ReportAssetType;
+
+  /**
+   * The ID of the asset according to its assetType.
+   */
+  assetId: number;
+}
+
 // ============================================================================
 // List Reports
 // ============================================================================
@@ -721,4 +818,32 @@ export interface SetReportPublishStatusResponse extends BaseResponseStatus {
    */
   failedItems?: FailedItem[];
   result: ReportPublish;
+}
+
+// ============================================================================
+// Add Report Scope
+// ============================================================================
+
+/**
+ * Options for adding report scope.
+ */
+export interface AddReportScopeOptions extends RequestOptions<never, ReportScopeAsset[]> {
+  /**
+   * Report ID.
+   */
+  reportId: number;
+}
+
+// ============================================================================
+// Remove Report Scope
+// ============================================================================
+
+/**
+ * Options for removing report scope.
+ */
+export interface RemoveReportScopeOptions extends RequestOptions<never, ReportScopeAsset[]> {
+  /**
+   * Report ID.
+   */
+  reportId: number;
 }

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -178,14 +178,14 @@ export interface ReportsApi {
 
   /**
    * Deletes the specified Report.
-   * 
+   *
    * @param options - {@link DeleteReportOptions} - Configuration options for the request
    * @param callback - {@link RequestCallback}\<{@link DeleteReportResponse}\> - Optional callback function
    * @returns Promise\<{@link DeleteReportResponse}\>
-   * 
+   *
    * @remarks
    * It mirrors to the following Smartsheet REST API method: `DELETE /2.0/reports/{reportId}`
-   * 
+   *
    * @example
    * ```typescript
    * const result = await client.reports.deleteReport({

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -326,6 +326,53 @@ export interface ReportsApi {
     options: RemoveReportScopeOptions,
     callback?: RequestCallback<BaseResponseStatus>
   ) => Promise<BaseResponseStatus>;
+
+  /**
+   * Add columns to a report.
+   *
+   * This operation adds columns to a report specified by a report ID.
+   *
+   * **Note:** All indexes of the columns must be equal.
+   *
+   * @param options - {@link AddReportColumnsOptions} - Configuration options for the request
+   * @param callback - {@link RequestCallback}\<{@link AddReportColumnsResponse}\> - Optional callback function
+   * @returns Promise\<{@link AddReportColumnsResponse}\>
+   *
+   * @remarks
+   * **Who can use this operation:**
+   * - **Permissions:** EDITOR or ADMIN access to the report
+   *
+   * **Additional notes:**
+   * - Maximum of 400 columns can be added
+   * - Column limit of 400 total columns per report
+   * - Cannot modify program reports via API
+   *
+   * It mirrors to the following Smartsheet REST API method: `POST /reports/{reportId}/columns`
+   *
+   * @example
+   * ```typescript
+   * const result = await client.reports.addReportColumns({
+   *   reportId: 4583173393803140,
+   *   body: [
+   *     {
+   *       title: 'Item selected',
+   *       type: 'CHECKBOX',
+   *       index: 4
+   *     },
+   *     {
+   *       title: 'Sheet name',
+   *       type: 'TEXT_NUMBER',
+   *       sheetNameColumn: true,
+   *       index: 4
+   *     }
+   *   ]
+   * });
+   * ```
+   */
+  addReportColumns: (
+    options: AddReportColumnsOptions,
+    callback?: RequestCallback<AddReportColumnsResponse>
+  ) => Promise<AddReportColumnsResponse>;
 }
 
 // ============================================================================
@@ -985,7 +1032,9 @@ export enum ReportAggregationType {
 }
 
 /**
- * Column types for report column identifiers.
+ * Column types for report columns and column identifiers.
+ *
+ * Used by {@link ReportColumn} and {@link ReportColumnIdentifier}.
  */
 export enum ReportColumnType {
   CHECKBOX = 'CHECKBOX',
@@ -1001,7 +1050,9 @@ export enum ReportColumnType {
 }
 
 /**
- * System column types for report column identifiers.
+ * System column types for report columns and column identifiers.
+ *
+ * Used by {@link ReportColumn} and {@link ReportColumnIdentifier}.
  */
 export enum ReportSystemColumnType {
   CREATED_BY = 'CREATED_BY',
@@ -1294,4 +1345,135 @@ export interface RemoveReportScopeOptions extends RequestOptions<never, ReportSc
    * Report ID.
    */
   reportId: number;
+}
+
+// ============================================================================
+// Add Report Columns
+// ============================================================================
+
+/**
+ * Auto-number format for report columns.
+ */
+export interface ReportColumnAutoNumberFormat {
+  /**
+   * Indicates zero-padding. It must be between 0 and 10 "0" (zero) characters.
+   */
+  fill: string;
+  /**
+   * The prefix. Can include these date tokens:
+   * - {DD}
+   * - {MM}
+   * - {YY}
+   * - {YYYY}
+   */
+  prefix: string;
+  /**
+   * The starting number for the auto-ID.
+   */
+  startingNumber: number;
+  /**
+   * The suffix. Can include these date tokens:
+   * - {DD}
+   * - {MM}
+   * - {YY}
+   * - {YYYY}
+   */
+  suffix: string;
+}
+
+/**
+ * Represents a report column.
+ *
+ * **Important:** When adding multiple columns at once, all columns must have the same index value.
+ */
+export interface ReportColumn {
+  /**
+   * The virtual ID of this report column.
+   */
+  virtualId?: number;
+  /**
+   * Column index or position. This number is zero-based. Indicates the position of the column in the generated report.
+   *
+   * **Note:** When adding multiple columns, all indexes must be equal.
+   */
+  index: number;
+  /**
+   * Column title to be matched from the source sheets.
+   *
+   * Note:
+   * - If `primary` is **true** then this property can be used to customize the primary column title.
+   */
+  title: string;
+  /**
+   * Type of column to match. See [Column Types](/api/smartsheet/openapi/columns).
+   *
+   * Valid combinations with systemColumnType:
+   * - `type: TEXT_NUMBER` + `systemColumnType: AUTO_NUMBER`
+   * - `type: CONTACT_LIST` + `systemColumnType: CREATED_BY`
+   * - `type: DATETIME` + `systemColumnType: CREATED_DATE`
+   * - `type: CONTACT_LIST` + `systemColumnType: MODIFIED_BY`
+   * - `type: DATETIME` + `systemColumnType: MODIFIED_DATE`
+   */
+  type: ReportColumnType | string;
+  /**
+   * System column type to match. See [System Columns](/api/smartsheet/openapi/columns).
+   *
+   * Must be used in combination with `type`. See valid combinations above.
+   */
+  systemColumnType?: ReportSystemColumnType | string;
+  /**
+   * Set to `true` to match the primary column. When `true`, `type` and `systemColumnType` are not required.
+   */
+  primary?: boolean;
+  /**
+   * Set to `true` to match the special "Sheet Name" report column. Must be used with `type: TEXT_NUMBER`.
+   */
+  sheetNameColumn?: boolean;
+  /**
+   * Indicates whether the column is hidden.
+   */
+  hidden?: boolean;
+  /**
+   * Version of the column type:
+   * - `0`: CONTACT_LIST, PICKLIST, or TEXT_NUMBER.
+   * - `1`: MULTI_CONTACT_LIST.
+   * - `2`: MULTI_PICKLIST.
+   */
+  version?: 0 | 1 | 2;
+  /**
+   * Display width of the column in pixels.
+   */
+  width?: number;
+  /**
+   * Indicates whether validation has been enabled for the column (value = **true**).
+   */
+  validation?: boolean;
+  /**
+   * Specifies how to format values for an auto-generated numbers column.
+   */
+  autoNumberFormat?: ReportColumnAutoNumberFormat;
+}
+
+/**
+ * Options for adding columns to a report.
+ */
+export interface AddReportColumnsOptions extends RequestOptions<undefined, ReportColumn[]> {
+  /**
+   * Report ID.
+   */
+  reportId: number;
+}
+
+/**
+ * Response from adding columns to a report.
+ */
+export interface AddReportColumnsResponse extends BaseResponseStatus {
+  /**
+   * Array of BulkItemFailure objects which represents the items that failed to be added or updated.
+   */
+  failedItems?: FailedItem[];
+  /**
+   * Array of report columns that were added.
+   */
+  result: ReportColumn[];
 }

--- a/lib/utils/httpRequestor.js
+++ b/lib/utils/httpRequestor.js
@@ -146,7 +146,7 @@ export function create(requestorConfig) {
   };
 
   const methodHandler = (url, method, methodName, requestOptions, body) => {
-    if (methodName === 'POST' || methodName === 'PUT') {
+    if (methodName === 'POST' || methodName === 'PUT' || methodName === 'PATCH') {
       return method(url, body, requestOptions);
     }
 

--- a/lib/utils/httpRequestor.js
+++ b/lib/utils/httpRequestor.js
@@ -92,7 +92,7 @@ export function create(requestorConfig) {
 
   const postFile = (options, callback) => methodRequest(options, request.post, 'POST', callback, getFileBody(options));
 
-  const deleteFunc = (options, callback) => methodRequest(options, request.delete, 'DELETE', callback);
+  const deleteFunc = (options, callback) => methodRequest(options, request.delete, 'DELETE', callback, options.body);
 
   const put = (options, callback) => methodRequest(options, request.put, 'PUT', callback, options.body);
 
@@ -148,6 +148,11 @@ export function create(requestorConfig) {
   const methodHandler = (url, method, methodName, requestOptions, body) => {
     if (methodName === 'POST' || methodName === 'PUT') {
       return method(url, body, requestOptions);
+    }
+
+    if (methodName === 'DELETE' && body) {
+      // For DELETE requests with a body, axios requires the body to be in config.data
+      return method(url, { ...requestOptions, data: body });
     }
 
     return method(url, requestOptions);

--- a/test/functional/client.spec.ts
+++ b/test/functional/client.spec.ts
@@ -180,7 +180,7 @@ describe('Client Unit Tests', () => {
   describe('#reports', () => {
     it('should have reports object', () => {
       expect(smartsheet).toHaveProperty('reports');
-      expect(Object.keys(smartsheet.reports)).toHaveLength(17);
+      expect(Object.keys(smartsheet.reports)).toHaveLength(18);
     });
 
     it('should have get methods', () => {
@@ -192,6 +192,7 @@ describe('Client Unit Tests', () => {
     });
 
     it('should have create methods', () => {
+      expect(smartsheet.reports).toHaveProperty('createReport');
       expect(smartsheet.reports).toHaveProperty('addReportScope');
       expect(smartsheet.reports).toHaveProperty('addReportColumns');
     });

--- a/test/functional/client.spec.ts
+++ b/test/functional/client.spec.ts
@@ -195,6 +195,10 @@ describe('Client Unit Tests', () => {
       expect(smartsheet.reports).toHaveProperty('setReportPublishStatus');
       expect(smartsheet.reports).toHaveProperty('sendReportViaEmail');
     });
+
+    it('should have delete methods', () => {
+      expect(smartsheet.reports).toHaveProperty('deleteReport');
+    });
   });
 
   describe('#server', () => {

--- a/test/functional/client.spec.ts
+++ b/test/functional/client.spec.ts
@@ -180,7 +180,7 @@ describe('Client Unit Tests', () => {
   describe('#reports', () => {
     it('should have reports object', () => {
       expect(smartsheet).toHaveProperty('reports');
-      expect(Object.keys(smartsheet.reports)).toHaveLength(16);
+      expect(Object.keys(smartsheet.reports)).toHaveLength(17);
     });
 
     it('should have get methods', () => {
@@ -193,6 +193,7 @@ describe('Client Unit Tests', () => {
 
     it('should have create methods', () => {
       expect(smartsheet.reports).toHaveProperty('addReportScope');
+      expect(smartsheet.reports).toHaveProperty('addReportColumns');
     });
 
     it('should have update methods', () => {

--- a/test/functional/client.spec.ts
+++ b/test/functional/client.spec.ts
@@ -180,7 +180,7 @@ describe('Client Unit Tests', () => {
   describe('#reports', () => {
     it('should have reports object', () => {
       expect(smartsheet).toHaveProperty('reports');
-      expect(Object.keys(smartsheet.reports)).toHaveLength(15);
+      expect(Object.keys(smartsheet.reports)).toHaveLength(16);
     });
 
     it('should have get methods', () => {

--- a/test/functional/client.spec.ts
+++ b/test/functional/client.spec.ts
@@ -180,7 +180,7 @@ describe('Client Unit Tests', () => {
   describe('#reports', () => {
     it('should have reports object', () => {
       expect(smartsheet).toHaveProperty('reports');
-      expect(Object.keys(smartsheet.reports)).toHaveLength(12);
+      expect(Object.keys(smartsheet.reports)).toHaveLength(13);
     });
 
     it('should have get methods', () => {

--- a/test/functional/client.spec.ts
+++ b/test/functional/client.spec.ts
@@ -180,7 +180,7 @@ describe('Client Unit Tests', () => {
   describe('#reports', () => {
     it('should have reports object', () => {
       expect(smartsheet).toHaveProperty('reports');
-      expect(Object.keys(smartsheet.reports)).toHaveLength(12);
+      expect(Object.keys(smartsheet.reports)).toHaveLength(14);
     });
 
     it('should have get methods', () => {
@@ -194,6 +194,8 @@ describe('Client Unit Tests', () => {
     it('should have update methods', () => {
       expect(smartsheet.reports).toHaveProperty('setReportPublishStatus');
       expect(smartsheet.reports).toHaveProperty('sendReportViaEmail');
+      expect(smartsheet.reports).toHaveProperty('addReportScope');
+      expect(smartsheet.reports).toHaveProperty('removeReportScope');
     });
   });
 

--- a/test/functional/client.spec.ts
+++ b/test/functional/client.spec.ts
@@ -191,10 +191,16 @@ describe('Client Unit Tests', () => {
       expect(smartsheet.reports).toHaveProperty('getReportPublishStatus');
     });
 
+    it('should have create methods', () => {
+      expect(smartsheet.reports).toHaveProperty('addReportScope');
+    });
+
     it('should have update methods', () => {
       expect(smartsheet.reports).toHaveProperty('setReportPublishStatus');
       expect(smartsheet.reports).toHaveProperty('sendReportViaEmail');
-      expect(smartsheet.reports).toHaveProperty('addReportScope');
+    });
+
+    it('should have delete methods', () => {
       expect(smartsheet.reports).toHaveProperty('removeReportScope');
     });
   });

--- a/test/functional/endpoints.spec.ts
+++ b/test/functional/endpoints.spec.ts
@@ -103,6 +103,7 @@ describe('Method Unit Tests', () => {
                 { name: 'getReportAsCSV', stub: 'get', options: {reportId: 123}, expectedRequest: {url: "reports/123", accept: constants.acceptHeaders.textCsv }},
                 { name: 'getReportPublishStatus', stub: 'get', options: {reportId: 123}, expectedRequest: {url: "reports/123/publish" }},
                 { name: 'setReportPublishStatus', stub: 'put', options: {reportId: 123}, expectedRequest: {url: "reports/123/publish" }},
+                { name: 'deleteReport', stub: 'delete', options: {reportId:123}, expectedRequest: {url: "reports/123"}},
             ]
         },
         {

--- a/test/functional/endpoints.spec.ts
+++ b/test/functional/endpoints.spec.ts
@@ -104,6 +104,7 @@ describe('Method Unit Tests', () => {
                 { name: 'getReportPublishStatus', stub: 'get', options: {reportId: 123}, expectedRequest: {url: "reports/123/publish" }},
                 { name: 'setReportPublishStatus', stub: 'put', options: {reportId: 123}, expectedRequest: {url: "reports/123/publish" }},
                 { name: 'deleteReport', stub: 'delete', options: {reportId:123}, expectedRequest: {url: "reports/123"}},
+                { name: 'addReportColumns', stub: 'post', options: {reportId: 123}, expectedRequest: {url: "reports/123/columns" }},
             ]
         },
         {

--- a/test/mock-api/reports/add_report_columns.spec.ts
+++ b/test/mock-api/reports/add_report_columns.spec.ts
@@ -1,0 +1,383 @@
+import crypto from 'crypto';
+import { createClient, findWireMockRequest } from '../utils/utils';
+import { expect } from '@jest/globals';
+import {
+    TEST_REPORT_ID,
+    TEST_SUCCESS_MESSAGE,
+    TEST_SUCCESS_RESULT_CODE,
+    ERROR_500_STATUS_CODE,
+    ERROR_500_MESSAGE,
+    ERROR_400_STATUS_CODE,
+    ERROR_400_MESSAGE
+} from './common_test_constants';
+import { ReportColumnType, ReportSystemColumnType } from '../../../lib/reports/types';
+
+describe('Reports - addReportColumns endpoint tests', () => {
+    const client = createClient();
+
+    const testColumnsAllProperties = [
+        {
+            title: 'Item selected',
+            type: ReportColumnType.CHECKBOX,
+            index: 4
+        },
+        {
+            title: 'Sheet name',
+            type: ReportColumnType.TEXT_NUMBER,
+            sheetNameColumn: true,
+            index: 4
+        }
+    ];
+
+    const testColumnsRequiredProperties = [
+        {
+            title: 'Item selected',
+            type: ReportColumnType.CHECKBOX,
+            index: 4
+        },
+        {
+            title: 'Sheet name',
+            type: ReportColumnType.TEXT_NUMBER,
+            index: 4
+        }
+    ];
+
+    // Comprehensive request body with all possible fields for marshalling validation
+    const testColumnsCompleteStructure = [
+        {
+            index: 4,
+            title: 'Status Column',
+            type: ReportColumnType.PICKLIST,
+            hidden: false,
+            width: 150
+        },
+        {
+            index: 4,
+            title: 'Task Name',
+            type: ReportColumnType.TEXT_NUMBER,
+            primary: true,
+            hidden: false,
+            width: 200
+        },
+        {
+            index: 4,
+            title: 'Created By',
+            type: ReportColumnType.CONTACT_LIST,
+            systemColumnType: ReportSystemColumnType.CREATED_BY,
+            hidden: false,
+            width: 120
+        },
+        {
+            index: 4,
+            title: 'Modified Date',
+            type: ReportColumnType.DATETIME,
+            systemColumnType: ReportSystemColumnType.MODIFIED_DATE,
+            hidden: true,
+            width: 100
+        },
+        {
+            index: 4,
+            title: 'Sheet Name',
+            type: ReportColumnType.TEXT_NUMBER,
+            sheetNameColumn: true,
+            hidden: false,
+            width: 180
+        }
+    ];
+
+    it('addReportColumns generated url is correct', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testColumnsAllProperties,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/add-report-columns/all-response-body-properties'
+            }
+        };
+        await client.reports.addReportColumns(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        const parsedUrl = new URL(matchedRequest.absoluteUrl);
+        expect(parsedUrl.pathname).toEqual(`/2.0/reports/${TEST_REPORT_ID}/columns`);
+    });
+
+    it('addReportColumns uses POST method', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testColumnsAllProperties,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/add-report-columns/all-response-body-properties'
+            }
+        };
+        await client.reports.addReportColumns(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+        expect(matchedRequest.method).toEqual('POST');
+    });
+
+    it('addReportColumns all response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testColumnsAllProperties,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/add-report-columns/all-response-body-properties'
+            }
+        };
+        const response = await client.reports.addReportColumns(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(response).toEqual({
+            message: TEST_SUCCESS_MESSAGE,
+            resultCode: TEST_SUCCESS_RESULT_CODE,
+            result: [
+                {
+                    virtualId: 12345,
+                    index: 4,
+                    title: 'Item selected',
+                    type: 'CHECKBOX',
+                    hidden: false,
+                    version: 0,
+                    width: 150,
+                    validation: false
+                },
+                {
+                    virtualId: 12346,
+                    index: 5,
+                    title: 'Sheet name',
+                    type: 'TEXT_NUMBER',
+                    hidden: false,
+                    version: 0,
+                    width: 150,
+                    sheetNameColumn: true,
+                    validation: false
+                },
+                {
+                    virtualId: 12347,
+                    index: 6,
+                    title: 'Created By',
+                    type: 'CONTACT_LIST',
+                    systemColumnType: 'CREATED_BY',
+                    hidden: false,
+                    version: 0,
+                    width: 150,
+                    validation: false
+                },
+                {
+                    virtualId: 12348,
+                    index: 7,
+                    title: 'Primary',
+                    type: 'TEXT_NUMBER',
+                    primary: true,
+                    hidden: false,
+                    version: 0,
+                    width: 200,
+                    validation: false
+                },
+                {
+                    virtualId: 12349,
+                    index: 8,
+                    title: 'Row Number',
+                    type: 'TEXT_NUMBER',
+                    systemColumnType: 'AUTO_NUMBER',
+                    hidden: false,
+                    version: 0,
+                    width: 100,
+                    validation: false,
+                    autoNumberFormat: {
+                        fill: '000',
+                        prefix: 'TASK-',
+                        startingNumber: 1,
+                        suffix: ''
+                    }
+                }
+            ]
+        });
+
+        const body = JSON.parse(matchedRequest.body);
+        expect(body).toEqual(testColumnsAllProperties);
+    });
+
+    it('addReportColumns required response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testColumnsRequiredProperties,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/add-report-columns/required-response-body-properties'
+            }
+        };
+        const response = await client.reports.addReportColumns(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(response).toEqual({
+            message: TEST_SUCCESS_MESSAGE,
+            resultCode: TEST_SUCCESS_RESULT_CODE,
+            result: [
+                {
+                    virtualId: 12345,
+                    index: 4,
+                    title: 'Item selected',
+                    type: 'CHECKBOX',
+                    version: 0
+                },
+                {
+                    virtualId: 12346,
+                    index: 5,
+                    title: 'Sheet name',
+                    type: 'TEXT_NUMBER',
+                    sheetNameColumn: true,
+                    version: 0
+                },
+                {
+                    virtualId: 12347,
+                    index: 6,
+                    title: 'Created By',
+                    type: 'CONTACT_LIST',
+                    systemColumnType: 'CREATED_BY',
+                    version: 0
+                },
+                {
+                    virtualId: 12348,
+                    index: 7,
+                    title: 'Primary',
+                    type: 'TEXT_NUMBER',
+                    primary: true,
+                    version: 0
+                },
+                {
+                    virtualId: 12349,
+                    index: 8,
+                    title: 'Row Number',
+                    type: 'TEXT_NUMBER',
+                    systemColumnType: 'AUTO_NUMBER',
+                    version: 0,
+                    autoNumberFormat: {
+                        fill: '000',
+                        prefix: 'TASK-',
+                        startingNumber: 1,
+                        suffix: ''
+                    }
+                }
+            ]
+        });
+
+        const body = JSON.parse(matchedRequest.body);
+        expect(body).toEqual(testColumnsRequiredProperties);
+    });
+
+    it('addReportColumns error 500 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testColumnsAllProperties,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/500-response'
+            }
+        };
+        try {
+            await client.reports.addReportColumns(options);
+            expect(true).toBe(false); // Expected an error to be thrown
+        } catch (error: any) {
+            expect(error.statusCode).toBe(ERROR_500_STATUS_CODE);
+            expect(error.message).toBe(ERROR_500_MESSAGE);
+        }
+    });
+
+    it('addReportColumns error 400 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testColumnsAllProperties,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/400-response'
+            }
+        };
+        try {
+            await client.reports.addReportColumns(options);
+            expect(true).toBe(false); // Expected an error to be thrown
+        } catch (error: any) {
+            expect(error.statusCode).toBe(ERROR_400_STATUS_CODE);
+            expect(error.message).toBe(ERROR_400_MESSAGE);
+        }
+    });
+
+    it('addReportColumns request body marshalling validation', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testColumnsCompleteStructure,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/add-report-columns/all-response-body-properties'
+            }
+        };
+        await client.reports.addReportColumns(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        // Parse the request body sent by the SDK
+        const actualRequestBody = JSON.parse(matchedRequest.body);
+
+        // Validate that the entire request body structure matches exactly
+        // This protects against accidental field additions or removals in the ReportColumn type
+        expect(actualRequestBody).toEqual(testColumnsCompleteStructure);
+
+        // Additional validation: ensure each column has expected structure
+        expect(actualRequestBody).toHaveLength(5);
+
+        // Validate first column (PICKLIST)
+        expect(actualRequestBody[0]).toEqual({
+            index: 4,
+            title: 'Status Column',
+            type: 'PICKLIST',
+            hidden: false,
+            width: 150
+        });
+
+        // Validate second column (primary TEXT_NUMBER)
+        expect(actualRequestBody[1]).toEqual({
+            index: 4,
+            title: 'Task Name',
+            type: 'TEXT_NUMBER',
+            primary: true,
+            hidden: false,
+            width: 200
+        });
+
+        // Validate third column (system column CREATED_BY)
+        expect(actualRequestBody[2]).toEqual({
+            index: 4,
+            title: 'Created By',
+            type: 'CONTACT_LIST',
+            systemColumnType: 'CREATED_BY',
+            hidden: false,
+            width: 120
+        });
+
+        // Validate fourth column (system column MODIFIED_DATE)
+        expect(actualRequestBody[3]).toEqual({
+            index: 4,
+            title: 'Modified Date',
+            type: 'DATETIME',
+            systemColumnType: 'MODIFIED_DATE',
+            hidden: true,
+            width: 100
+        });
+
+        // Validate fifth column (sheet name column)
+        expect(actualRequestBody[4]).toEqual({
+            index: 4,
+            title: 'Sheet Name',
+            type: 'TEXT_NUMBER',
+            sheetNameColumn: true,
+            hidden: false,
+            width: 180
+        });
+    });
+});

--- a/test/mock-api/reports/add_report_columns.spec.ts
+++ b/test/mock-api/reports/add_report_columns.spec.ts
@@ -10,7 +10,7 @@ import {
     ERROR_400_STATUS_CODE,
     ERROR_400_MESSAGE
 } from './common_test_constants';
-import { ReportColumnType, ReportSystemColumnType } from '../../../lib/reports/types';
+import { ReportColumnType, SystemColumnType } from '../../../lib/reports/types';
 
 describe('Reports - addReportColumns endpoint tests', () => {
     const client = createClient();
@@ -63,7 +63,7 @@ describe('Reports - addReportColumns endpoint tests', () => {
             index: 4,
             title: 'Created By',
             type: ReportColumnType.CONTACT_LIST,
-            systemColumnType: ReportSystemColumnType.CREATED_BY,
+            systemColumnType: SystemColumnType.CREATED_BY,
             hidden: false,
             width: 120
         },
@@ -71,7 +71,7 @@ describe('Reports - addReportColumns endpoint tests', () => {
             index: 4,
             title: 'Modified Date',
             type: ReportColumnType.DATETIME,
-            systemColumnType: ReportSystemColumnType.MODIFIED_DATE,
+            systemColumnType: SystemColumnType.MODIFIED_DATE,
             hidden: true,
             width: 100
         },

--- a/test/mock-api/reports/add_report_scope.spec.ts
+++ b/test/mock-api/reports/add_report_scope.spec.ts
@@ -1,0 +1,111 @@
+import crypto from 'crypto';
+import { createClient, findWireMockRequest } from '../utils/utils';
+import { expect } from '@jest/globals';
+import {
+    TEST_REPORT_ID,
+    TEST_SHEET_ID,
+    TEST_WORKSPACE_ID,
+    TEST_ASSET_TYPE_SHEET,
+    TEST_ASSET_TYPE_WORKSPACE,
+    TEST_SUCCESS_MESSAGE,
+    TEST_SUCCESS_RESULT_CODE,
+    ERROR_500_STATUS_CODE,
+    ERROR_500_MESSAGE,
+    ERROR_400_STATUS_CODE,
+    ERROR_400_MESSAGE
+} from './common_test_constants';
+import { ReportAssetType } from '@smartsheet/reports/types';
+
+describe('Reports - addReportScope endpoint tests', () => {
+    const client = createClient();
+
+    it('addReportScope generated url is correct', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: [
+                { assetType: ReportAssetType.SHEET, assetId: TEST_SHEET_ID }
+            ],
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/add-report-scope/all-response-body-properties'
+            }
+        };
+        await client.reports.addReportScope(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        const parsedUrl = new URL(matchedRequest.absoluteUrl);
+        expect(parsedUrl.pathname).toEqual(`/2.0/reports/${TEST_REPORT_ID}/scope`);
+    });
+
+    it('addReportScope all response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const testBody = [
+            { assetType: ReportAssetType.SHEET, assetId: TEST_SHEET_ID },
+            { assetType: ReportAssetType.WORKSPACE, assetId: TEST_WORKSPACE_ID }
+        ];
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testBody,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/add-report-scope/all-response-body-properties'
+            }
+        };
+        const response = await client.reports.addReportScope(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(response).toEqual({
+            message: TEST_SUCCESS_MESSAGE,
+            resultCode: TEST_SUCCESS_RESULT_CODE
+        });
+
+        const body = JSON.parse(matchedRequest.body);
+        expect(body).toEqual([
+            { assetType: TEST_ASSET_TYPE_SHEET, assetId: TEST_SHEET_ID },
+            { assetType: TEST_ASSET_TYPE_WORKSPACE, assetId: TEST_WORKSPACE_ID }
+        ]);
+    });
+
+    it('addReportScope error 500 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: [
+                { assetType: ReportAssetType.SHEET, assetId: TEST_SHEET_ID }
+            ],
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/500-response'
+            }
+        };
+        try {
+            await client.reports.addReportScope(options);
+            expect(true).toBe(false); // Expected an error to be thrown
+        } catch (error) {
+            expect(error.statusCode).toBe(ERROR_500_STATUS_CODE);
+            expect(error.message).toBe(ERROR_500_MESSAGE);
+        }
+    });
+
+    it('addReportScope error 400 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: [
+                { assetType: ReportAssetType.SHEET, assetId: TEST_SHEET_ID }
+            ],
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/400-response'
+            }
+        };
+        try {
+            await client.reports.addReportScope(options);
+            expect(true).toBe(false); // Expected an error to be thrown
+        } catch (error) {
+            expect(error.statusCode).toBe(ERROR_400_STATUS_CODE);
+            expect(error.message).toBe(ERROR_400_MESSAGE);
+        }
+    });
+});

--- a/test/mock-api/reports/common_test_constants.ts
+++ b/test/mock-api/reports/common_test_constants.ts
@@ -50,8 +50,8 @@ export const TEST_SOURCE_WORKSPACE_PERMALINK = 'https://app.smartsheet.com/works
 // Report Scope Assets
 export const TEST_SHEET_ID = 9876543210;
 export const TEST_WORKSPACE_ID = 1122334455;
-export const TEST_ASSET_TYPE_SHEET = 'SHEET';
-export const TEST_ASSET_TYPE_WORKSPACE = 'WORKSPACE';
+export const TEST_ASSET_TYPE_SHEET = 'sheet';
+export const TEST_ASSET_TYPE_WORKSPACE = 'workspace';
 
 // Report Columns (Column type requires all these properties)
 export const TEST_COLUMN_1_ID = 1111111111111111;

--- a/test/mock-api/reports/common_test_constants.ts
+++ b/test/mock-api/reports/common_test_constants.ts
@@ -47,6 +47,12 @@ export const TEST_SOURCE_WORKSPACE_NAME = 'Source Workspace';
 export const TEST_SOURCE_WORKSPACE_ACCESS_LEVEL = 'VIEWER';
 export const TEST_SOURCE_WORKSPACE_PERMALINK = 'https://app.smartsheet.com/workspaces/source-workspace';
 
+// Report Scope Assets
+export const TEST_SHEET_ID = 9876543210;
+export const TEST_WORKSPACE_ID = 1122334455;
+export const TEST_ASSET_TYPE_SHEET = 'SHEET';
+export const TEST_ASSET_TYPE_WORKSPACE = 'WORKSPACE';
+
 // Report Columns (Column type requires all these properties)
 export const TEST_COLUMN_1_ID = 1111111111111111;
 export const TEST_COLUMN_1_INDEX = 0;

--- a/test/mock-api/reports/create_report.spec.ts
+++ b/test/mock-api/reports/create_report.spec.ts
@@ -1,0 +1,297 @@
+import crypto from 'crypto';
+import { createClient, findWireMockRequest } from '../utils/utils';
+import { expect } from '@jest/globals';
+import {
+    TEST_SUCCESS_MESSAGE,
+    TEST_SUCCESS_RESULT_CODE,
+    ERROR_500_STATUS_CODE,
+    ERROR_500_MESSAGE,
+    ERROR_400_STATUS_CODE,
+    ERROR_400_MESSAGE
+} from './common_test_constants';
+import { ReportColumnType, SystemColumnType, ReportAssetType, ReportDestinationType } from '../../../lib/reports/types';
+
+describe('Reports - createReport endpoint tests', () => {
+    const client = createClient();
+
+    const testCreateReportRequired = {
+        name: 'Q2 Earnings Report',
+        destination: {
+            destinationType: ReportDestinationType.FOLDER,
+            destinationId: 1234567890
+        },
+        columns: [
+            {
+                title: 'Primary',
+                type: ReportColumnType.TEXT_NUMBER,
+                primary: true,
+                index: 0
+            }
+        ],
+        scope: [
+            {
+                assetType: ReportAssetType.SHEET,
+                assetId: 9876543210
+            }
+        ]
+    };
+
+    const testCreateReportAllProperties = {
+        name: 'Q2 Project Status',
+        destination: {
+            destinationType: ReportDestinationType.WORKSPACE,
+            destinationId: 5555555555
+        },
+        columns: [
+            {
+                title: 'Primary',
+                type: ReportColumnType.TEXT_NUMBER,
+                primary: true,
+                index: 0
+            },
+            {
+                title: 'Status',
+                type: ReportColumnType.PICKLIST,
+                index: 1,
+                hidden: false,
+                width: 150
+            },
+            {
+                title: 'Created By',
+                type: ReportColumnType.CONTACT_LIST,
+                systemColumnType: SystemColumnType.CREATED_BY,
+                index: 2
+            }
+        ],
+        scope: [
+            {
+                assetType: ReportAssetType.SHEET,
+                assetId: 9876543210
+            },
+            {
+                assetType: ReportAssetType.WORKSPACE,
+                assetId: 1122334455
+            }
+        ],
+        reportDefinition: {
+            filters: {
+                operator: 'AND',
+                criteria: [
+                    {
+                        column: {
+                            title: 'Status',
+                            type: 'PICKLIST'
+                        },
+                        operator: 'EQUAL',
+                        values: ['In Progress']
+                    }
+                ]
+            },
+            sortingCriteria: [
+                {
+                    column: {
+                        title: 'Primary',
+                        type: 'TEXT_NUMBER',
+                        primary: true
+                    },
+                    sortingDirection: 'ASCENDING'
+                }
+            ]
+        },
+        isSummaryReport: false
+    };
+
+    it('createReport generated url is correct', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            body: testCreateReportRequired,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/create-report/required-response-body-properties'
+            }
+        };
+        await client.reports.createReport(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        const parsedUrl = new URL(matchedRequest.absoluteUrl);
+        expect(parsedUrl.pathname).toEqual('/2.0/reports');
+    });
+
+    it('createReport uses POST method', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            body: testCreateReportRequired,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/create-report/required-response-body-properties'
+            }
+        };
+        await client.reports.createReport(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+        expect(matchedRequest.method).toEqual('POST');
+    });
+
+    it('createReport required response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            body: testCreateReportRequired,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/create-report/required-response-body-properties'
+            }
+        };
+        const response = await client.reports.createReport(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(response).toEqual({
+            message: TEST_SUCCESS_MESSAGE,
+            resultCode: TEST_SUCCESS_RESULT_CODE,
+            result: [
+                {
+                    id: 4583614634583940,
+                    name: 'Q2 Earnings',
+                    accessLevel: 'OWNER',
+                    permalink: 'https://app.smartsheet.com/reports/c8gJxw87cXpRCvCC5PPw6jFhFRrf5r8PxCrxvW21'
+                }
+            ]
+        });
+
+        const body = JSON.parse(matchedRequest.body);
+        expect(body).toEqual(testCreateReportRequired);
+    });
+
+    it('createReport all response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            body: testCreateReportAllProperties,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/create-report/all-response-body-properties'
+            }
+        };
+        const response = await client.reports.createReport(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(response).toEqual({
+            message: TEST_SUCCESS_MESSAGE,
+            resultCode: TEST_SUCCESS_RESULT_CODE,
+            result: [
+                {
+                    id: 4583614634583940,
+                    name: 'Q2 Earnings',
+                    accessLevel: 'OWNER',
+                    permalink: 'https://app.smartsheet.com/reports/c8gJxw87cXpRCvCC5PPw6jFhFRrf5r8PxCrxvW21',
+                    isSummaryReport: false
+                }
+            ]
+        });
+
+        const body = JSON.parse(matchedRequest.body);
+        expect(body).toEqual(testCreateReportAllProperties);
+    });
+
+    it('createReport request body marshalling validation', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            body: testCreateReportAllProperties,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/create-report/all-response-body-properties'
+            }
+        };
+        await client.reports.createReport(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        // Parse the request body sent by the SDK
+        const actualRequestBody = JSON.parse(matchedRequest.body);
+
+        // Validate that the entire request body structure matches exactly
+        expect(actualRequestBody).toEqual(testCreateReportAllProperties);
+
+        // Validate top-level properties
+        expect(actualRequestBody.name).toBe('Q2 Project Status');
+        expect(actualRequestBody.isSummaryReport).toBe(false);
+
+        // Validate destination structure
+        expect(actualRequestBody.destination).toEqual({
+            destinationType: 'workspace',
+            destinationId: 5555555555
+        });
+
+        // Validate columns array
+        expect(actualRequestBody.columns).toHaveLength(3);
+        expect(actualRequestBody.columns[0]).toEqual({
+            title: 'Primary',
+            type: 'TEXT_NUMBER',
+            primary: true,
+            index: 0
+        });
+        expect(actualRequestBody.columns[1]).toEqual({
+            title: 'Status',
+            type: 'PICKLIST',
+            index: 1,
+            hidden: false,
+            width: 150
+        });
+        expect(actualRequestBody.columns[2]).toEqual({
+            title: 'Created By',
+            type: 'CONTACT_LIST',
+            systemColumnType: 'CREATED_BY',
+            index: 2
+        });
+
+        // Validate scope array
+        expect(actualRequestBody.scope).toHaveLength(2);
+        expect(actualRequestBody.scope[0]).toEqual({
+            assetType: 'sheet',
+            assetId: 9876543210
+        });
+        expect(actualRequestBody.scope[1]).toEqual({
+            assetType: 'workspace',
+            assetId: 1122334455
+        });
+
+        // Validate report definition
+        expect(actualRequestBody.reportDefinition).toBeDefined();
+        expect(actualRequestBody.reportDefinition.filters).toBeDefined();
+        expect(actualRequestBody.reportDefinition.filters.operator).toBe('AND');
+        expect(actualRequestBody.reportDefinition.filters.criteria).toHaveLength(1);
+        expect(actualRequestBody.reportDefinition.sortingCriteria).toHaveLength(1);
+    });
+
+    it('createReport error 500 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            body: testCreateReportRequired,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/500-response'
+            }
+        };
+        try {
+            await client.reports.createReport(options);
+            expect(true).toBe(false); // Expected an error to be thrown
+        } catch (error: any) {
+            expect(error.statusCode).toBe(ERROR_500_STATUS_CODE);
+            expect(error.message).toBe(ERROR_500_MESSAGE);
+        }
+    });
+
+    it('createReport error 400 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            body: testCreateReportRequired,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/400-response'
+            }
+        };
+        try {
+            await client.reports.createReport(options);
+            expect(true).toBe(false); // Expected an error to be thrown
+        } catch (error: any) {
+            expect(error.statusCode).toBe(ERROR_400_STATUS_CODE);
+            expect(error.message).toBe(ERROR_400_MESSAGE);
+        }
+    });
+});

--- a/test/mock-api/reports/create_report.spec.ts
+++ b/test/mock-api/reports/create_report.spec.ts
@@ -146,14 +146,12 @@ describe('Reports - createReport endpoint tests', () => {
         expect(response).toEqual({
             message: TEST_SUCCESS_MESSAGE,
             resultCode: TEST_SUCCESS_RESULT_CODE,
-            result: [
-                {
-                    id: 4583614634583940,
-                    name: 'Q2 Earnings',
-                    accessLevel: 'OWNER',
-                    permalink: 'https://app.smartsheet.com/reports/c8gJxw87cXpRCvCC5PPw6jFhFRrf5r8PxCrxvW21'
-                }
-            ]
+            result: {
+                id: 987654321,
+                name: 'Q2 Earnings Report',
+                accessLevel: 'OWNER',
+                permalink: 'https://app.smartsheet.com/reports/c8gJxw87cXpRCvCC5PPw6jFhFRrf5r8PxCrxvW21'
+            }
         });
 
         const body = JSON.parse(matchedRequest.body);
@@ -175,15 +173,58 @@ describe('Reports - createReport endpoint tests', () => {
         expect(response).toEqual({
             message: TEST_SUCCESS_MESSAGE,
             resultCode: TEST_SUCCESS_RESULT_CODE,
-            result: [
-                {
-                    id: 4583614634583940,
-                    name: 'Q2 Earnings',
-                    accessLevel: 'OWNER',
-                    permalink: 'https://app.smartsheet.com/reports/c8gJxw87cXpRCvCC5PPw6jFhFRrf5r8PxCrxvW21',
-                    isSummaryReport: false
-                }
-            ]
+            result: {
+                id: 987654321,
+                name: 'Q2 Earnings Report',
+                accessLevel: 'OWNER',
+                permalink: 'https://app.smartsheet.com/reports/c8gJxw87cXpRCvCC5PPw6jFhFRrf5r8PxCrxvW21',
+                isSummaryReport: false,
+                columns: [
+                    {
+                        virtualId: 1234567890123456,
+                        index: 0,
+                        title: 'Primary column',
+                        type: 'TEXT_NUMBER',
+                        primary: true,
+                        hidden: false,
+                        version: 0,
+                        width: 200,
+                        validation: false
+                    },
+                    {
+                        virtualId: 2345678901234567,
+                        index: 1,
+                        title: 'Sheet name',
+                        type: 'TEXT_NUMBER',
+                        sheetNameColumn: true,
+                        hidden: false,
+                        version: 0,
+                        width: 150,
+                        validation: false
+                    },
+                    {
+                        virtualId: 3456789012345678,
+                        index: 2,
+                        title: 'Created at',
+                        type: 'DATETIME',
+                        systemColumnType: 'CREATED_DATE',
+                        hidden: false,
+                        version: 0,
+                        width: 150,
+                        validation: false
+                    },
+                    {
+                        virtualId: 4567890123456789,
+                        index: 3,
+                        title: 'Selected item',
+                        type: 'PICKLIST',
+                        hidden: false,
+                        version: 0,
+                        width: 150,
+                        validation: false
+                    }
+                ]
+            }
         });
 
         const body = JSON.parse(matchedRequest.body);

--- a/test/mock-api/reports/delete-reports.spec.ts
+++ b/test/mock-api/reports/delete-reports.spec.ts
@@ -1,0 +1,96 @@
+import crypto from 'crypto';
+import { createClient, findWireMockRequest } from '../utils/utils';
+import { expect } from '@jest/globals';
+import {
+    TEST_REPORT_ID,
+    TEST_REPORT_NAME,
+    TEST_REPORT_PERMALINK,
+    TEST_REPORT_ACCESS_LEVEL,
+    TEST_MODIFIED_SINCE,
+    TEST_SUCCESS_MESSAGE,
+    TEST_SUCCESS_RESULT_CODE,
+    ERROR_500_STATUS_CODE,
+    ERROR_500_MESSAGE,
+    ERROR_400_STATUS_CODE,
+    ERROR_400_MESSAGE
+} from './common_test_constants';
+
+describe('Reports - deleteReport endpoint tests', () => {
+    const client = createClient();
+
+    it('deleteReport generated url is correct', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/delete-report/all-response-body-properties'
+            }
+        };
+        await client.reports.deleteReport(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+        const parsedUrl = new URL(matchedRequest.absoluteUrl);
+        expect(parsedUrl.pathname).toEqual("/2.0/reports/" + TEST_REPORT_ID);
+
+        const queryParamsObject = Object.fromEntries(parsedUrl.searchParams);
+        expect(queryParamsObject).toEqual({
+            reportId: TEST_REPORT_ID
+        });
+    });
+
+    it('deleteReport all response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/delete-report/all-response-body-properties'
+            }
+        };
+        
+        const response = await client.reports.deleteReport(options);
+
+        expect(response).toEqual({
+            message: TEST_SUCCESS_MESSAGE,
+            resultCode: TEST_SUCCESS_RESULT_CODE
+        });
+    });
+
+    it('deleteReport error 500 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/500-response'
+            }
+        };
+
+        try {
+            await client.reports.deleteReport(options);
+            expect(true).toBe(false); // Expected an error to be thrown
+        } catch (error) {
+            expect(error.statusCode).toBe(ERROR_500_STATUS_CODE);
+            expect(error.message).toBe(ERROR_500_MESSAGE);
+        }
+    });
+
+    it('listReports error 400 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/400-response'
+            }
+        };
+
+        try {
+            await client.reports.deleteReport(options);
+            expect(true).toBe(false); // Expected an error to be thrown
+        } catch (error) {
+            expect(error.statusCode).toBe(ERROR_400_STATUS_CODE);
+            expect(error.message).toBe(ERROR_400_MESSAGE);
+        }
+    });
+});

--- a/test/mock-api/reports/delete-reports.spec.ts
+++ b/test/mock-api/reports/delete-reports.spec.ts
@@ -3,10 +3,6 @@ import { createClient, findWireMockRequest } from '../utils/utils';
 import { expect } from '@jest/globals';
 import {
     TEST_REPORT_ID,
-    TEST_REPORT_NAME,
-    TEST_REPORT_PERMALINK,
-    TEST_REPORT_ACCESS_LEVEL,
-    TEST_MODIFIED_SINCE,
     TEST_SUCCESS_MESSAGE,
     TEST_SUCCESS_RESULT_CODE,
     ERROR_500_STATUS_CODE,

--- a/test/mock-api/reports/delete-reports.spec.ts
+++ b/test/mock-api/reports/delete-reports.spec.ts
@@ -75,7 +75,7 @@ describe('Reports - deleteReport endpoint tests', () => {
         }
     });
 
-    it('listReports error 400 response', async () => {
+    it('deleteReport error 400 response', async () => {
         const requestId = crypto.randomUUID();
         const options = {
             reportId: TEST_REPORT_ID,

--- a/test/mock-api/reports/delete-reports.spec.ts
+++ b/test/mock-api/reports/delete-reports.spec.ts
@@ -21,17 +21,13 @@ describe('Reports - deleteReport endpoint tests', () => {
             customProperties: {
                 'x-request-id': requestId,
                 'x-test-name': '/reports/delete-report/all-response-body-properties'
+                
             }
         };
         await client.reports.deleteReport(options);
         const matchedRequest = await findWireMockRequest(requestId);
         const parsedUrl = new URL(matchedRequest.absoluteUrl);
         expect(parsedUrl.pathname).toEqual("/2.0/reports/" + TEST_REPORT_ID);
-
-        const queryParamsObject = Object.fromEntries(parsedUrl.searchParams);
-        expect(queryParamsObject).toEqual({
-            reportId: TEST_REPORT_ID
-        });
     });
 
     it('deleteReport all response body properties', async () => {

--- a/test/mock-api/reports/remove_report_scope.spec.ts
+++ b/test/mock-api/reports/remove_report_scope.spec.ts
@@ -5,6 +5,8 @@ import {
     TEST_REPORT_ID,
     TEST_SHEET_ID,
     TEST_WORKSPACE_ID,
+    TEST_ASSET_TYPE_SHEET,
+    TEST_ASSET_TYPE_WORKSPACE,
     TEST_SUCCESS_MESSAGE,
     TEST_SUCCESS_RESULT_CODE,
     ERROR_500_STATUS_CODE,
@@ -50,11 +52,18 @@ describe('Reports - removeReportScope endpoint tests', () => {
             }
         };
         const response = await client.reports.removeReportScope(options);
+        const matchedRequest = await findWireMockRequest(requestId);
 
         expect(response).toEqual({
             message: TEST_SUCCESS_MESSAGE,
             resultCode: TEST_SUCCESS_RESULT_CODE
         });
+
+        const body = JSON.parse(matchedRequest.body);
+        expect(body).toEqual([
+            { assetType: TEST_ASSET_TYPE_SHEET, assetId: TEST_SHEET_ID },
+            { assetType: TEST_ASSET_TYPE_WORKSPACE, assetId: TEST_WORKSPACE_ID }
+        ]);
     });
 
     it('removeReportScope error 500 response', async () => {

--- a/test/mock-api/reports/remove_report_scope.spec.ts
+++ b/test/mock-api/reports/remove_report_scope.spec.ts
@@ -1,0 +1,101 @@
+import crypto from 'crypto';
+import { createClient, findWireMockRequest } from '../utils/utils';
+import { expect } from '@jest/globals';
+import {
+    TEST_REPORT_ID,
+    TEST_SHEET_ID,
+    TEST_WORKSPACE_ID,
+    TEST_SUCCESS_MESSAGE,
+    TEST_SUCCESS_RESULT_CODE,
+    ERROR_500_STATUS_CODE,
+    ERROR_500_MESSAGE,
+    ERROR_400_STATUS_CODE,
+    ERROR_400_MESSAGE
+} from './common_test_constants';
+import { ReportAssetType } from '@smartsheet/reports/types';
+
+describe('Reports - removeReportScope endpoint tests', () => {
+    const client = createClient();
+
+    it('removeReportScope generated url is correct', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: [
+                { assetType: ReportAssetType.SHEET, assetId: TEST_SHEET_ID }
+            ],
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/remove-report-scope/all-response-body-properties'
+            }
+        };
+        await client.reports.removeReportScope(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        const parsedUrl = new URL(matchedRequest.absoluteUrl);
+        expect(parsedUrl.pathname).toEqual(`/2.0/reports/${TEST_REPORT_ID}/scope`);
+    });
+
+    it('removeReportScope all response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: [
+                { assetType: ReportAssetType.SHEET, assetId: TEST_SHEET_ID },
+                { assetType: ReportAssetType.WORKSPACE, assetId: TEST_WORKSPACE_ID }
+            ],
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/remove-report-scope/all-response-body-properties'
+            }
+        };
+        const response = await client.reports.removeReportScope(options);
+
+        expect(response).toEqual({
+            message: TEST_SUCCESS_MESSAGE,
+            resultCode: TEST_SUCCESS_RESULT_CODE
+        });
+    });
+
+    it('removeReportScope error 500 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: [
+                { assetType: ReportAssetType.SHEET, assetId: TEST_SHEET_ID }
+            ],
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/500-response'
+            }
+        };
+        try {
+            await client.reports.removeReportScope(options);
+            expect(true).toBe(false); // Expected an error to be thrown
+        } catch (error) {
+            expect(error.statusCode).toBe(ERROR_500_STATUS_CODE);
+            expect(error.message).toBe(ERROR_500_MESSAGE);
+        }
+    });
+
+    it('removeReportScope error 400 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: [
+                { assetType: ReportAssetType.SHEET, assetId: TEST_SHEET_ID }
+            ],
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/400-response'
+            }
+        };
+        try {
+            await client.reports.removeReportScope(options);
+            expect(true).toBe(false); // Expected an error to be thrown
+        } catch (error) {
+            expect(error.statusCode).toBe(ERROR_400_STATUS_CODE);
+            expect(error.message).toBe(ERROR_400_MESSAGE);
+        }
+    });
+});

--- a/test/mock-api/reports/update_report_definition.spec.ts
+++ b/test/mock-api/reports/update_report_definition.spec.ts
@@ -10,62 +10,70 @@ import {
     ERROR_400_STATUS_CODE,
     ERROR_400_MESSAGE
 } from './common_test_constants';
+import {
+    ReportColumnType,
+    ReportSystemColumnType,
+    ReportFilterOperator,
+    ReportFilterConditionOperator,
+    ReportSortingDirection,
+    ReportAggregationType
+} from '../../../lib/reports/types';
 
 describe('Reports - updateReportDefinition endpoint tests', () => {
     const client = createClient();
 
     const testFilterOnlyBody = {
         filters: {
-            operator: 'OR',
+            operator: ReportFilterOperator.OR,
             criteria: [
                 {
-                    column: { title: 'Status', type: 'PICKLIST' },
-                    operator: 'EQUAL',
+                    column: { title: 'Status', type: ReportColumnType.PICKLIST },
+                    operator: ReportFilterConditionOperator.EQUAL,
                     values: ['Complete']
                 },
                 {
-                    column: { title: 'Priority', type: 'TEXT_NUMBER' },
-                    operator: 'GREATER_THAN',
+                    column: { title: 'Priority', type: ReportColumnType.TEXT_NUMBER },
+                    operator: ReportFilterConditionOperator.GREATER_THAN,
                     values: [5]
                 },
                 {
-                    column: { title: 'Due Date', type: 'DATE' },
-                    operator: 'GREATER_THAN',
+                    column: { title: 'Due Date', type: ReportColumnType.DATE },
+                    operator: ReportFilterConditionOperator.GREATER_THAN,
                     values: [{ objectType: 'DATE', value: '2024-01-01' }]
                 },
                 {
-                    column: { title: 'Assigned To', type: 'CONTACT_LIST' },
-                    operator: 'EQUAL',
+                    column: { title: 'Assigned To', type: ReportColumnType.CONTACT_LIST },
+                    operator: ReportFilterConditionOperator.EQUAL,
                     values: [{ objectType: 'CURRENT_USER', value: '' }]
                 },
                 {
-                    column: { primary: true, type: 'TEXT_NUMBER' },
-                    operator: 'CONTAINS',
+                    column: { primary: true, type: ReportColumnType.TEXT_NUMBER },
+                    operator: ReportFilterConditionOperator.CONTAINS,
                     values: ['PROJ-1']
                 },
                 {
-                    column: { systemColumnType: 'CREATED_BY', type: 'TEXT_NUMBER' },
-                    operator: 'NOT_EQUAL',
+                    column: { systemColumnType: ReportSystemColumnType.CREATED_BY, type: ReportColumnType.TEXT_NUMBER },
+                    operator: ReportFilterConditionOperator.NOT_EQUAL,
                     values: ['System']
                 },
                 {
-                    column: { sheetNameColumn: true, type: 'TEXT_NUMBER' },
-                    operator: 'IS_ONE_OF',
+                    column: { sheetNameColumn: true, type: ReportColumnType.TEXT_NUMBER },
+                    operator: ReportFilterConditionOperator.IS_ONE_OF,
                     values: ['Project A', 'Project B']
                 }
             ],
             nestedCriteria: [
                 {
-                    operator: 'AND',
+                    operator: ReportFilterOperator.AND,
                     criteria: [
                         {
-                            column: { title: 'Start Date', type: 'DATE' },
-                            operator: 'LAST_N_DAYS',
+                            column: { title: 'Start Date', type: ReportColumnType.DATE },
+                            operator: ReportFilterConditionOperator.LAST_N_DAYS,
                             values: [30]
                         },
                         {
-                            column: { title: 'Completed', type: 'CHECKBOX' },
-                            operator: 'IS_CHECKED',
+                            column: { title: 'Completed', type: ReportColumnType.CHECKBOX },
+                            operator: ReportFilterConditionOperator.IS_CHECKED,
                             values: []
                         }
                     ]
@@ -74,38 +82,38 @@ describe('Reports - updateReportDefinition endpoint tests', () => {
         },
         groupingCriteria: [
             {
-                column: { title: 'Department', type: 'PICKLIST' },
-                sortingDirection: 'ASCENDING',
+                column: { title: 'Department', type: ReportColumnType.PICKLIST },
+                sortingDirection: ReportSortingDirection.ASCENDING,
                 isExpanded: true
             },
             {
-                column: { title: 'Priority', type: 'TEXT_NUMBER' },
-                sortingDirection: 'DESCENDING',
+                column: { title: 'Priority', type: ReportColumnType.TEXT_NUMBER },
+                sortingDirection: ReportSortingDirection.DESCENDING,
                 isExpanded: false
             }
         ],
         summarizingCriteria: [
             {
-                column: { title: 'Cost', type: 'TEXT_NUMBER' },
-                aggregationType: 'SUM'
+                column: { title: 'Cost', type: ReportColumnType.TEXT_NUMBER },
+                aggregationType: ReportAggregationType.SUM
             },
             {
-                column: { title: 'Duration', type: 'DURATION' },
-                aggregationType: 'AVG'
+                column: { title: 'Duration', type: ReportColumnType.DURATION },
+                aggregationType: ReportAggregationType.AVG
             },
             {
-                column: { title: 'Task Count', type: 'TEXT_NUMBER' },
-                aggregationType: 'COUNT'
+                column: { title: 'Task Count', type: ReportColumnType.TEXT_NUMBER },
+                aggregationType: ReportAggregationType.COUNT
             }
         ],
         sortingCriteria: [
             {
-                column: { title: 'Due Date', type: 'DATE' },
-                sortingDirection: 'ASCENDING'
+                column: { title: 'Due Date', type: ReportColumnType.DATE },
+                sortingDirection: ReportSortingDirection.ASCENDING
             },
             {
-                column: { title: 'Priority', type: 'TEXT_NUMBER' },
-                sortingDirection: 'DESCENDING'
+                column: { title: 'Priority', type: ReportColumnType.TEXT_NUMBER },
+                sortingDirection: ReportSortingDirection.DESCENDING
             }
         ]
     };

--- a/test/mock-api/reports/update_report_definition.spec.ts
+++ b/test/mock-api/reports/update_report_definition.spec.ts
@@ -1,0 +1,204 @@
+import crypto from 'crypto';
+import { createClient, findWireMockRequest } from '../utils/utils';
+import { expect } from '@jest/globals';
+import {
+    TEST_REPORT_ID,
+    TEST_SUCCESS_MESSAGE,
+    TEST_SUCCESS_RESULT_CODE,
+    ERROR_500_STATUS_CODE,
+    ERROR_500_MESSAGE,
+    ERROR_400_STATUS_CODE,
+    ERROR_400_MESSAGE
+} from './common_test_constants';
+
+describe('Reports - updateReportDefinition endpoint tests', () => {
+    const client = createClient();
+
+    const testFilterOnlyBody = {
+        filters: {
+            operator: 'OR',
+            criteria: [
+                {
+                    column: { title: 'Status', type: 'PICKLIST' },
+                    operator: 'EQUAL',
+                    values: ['Complete']
+                },
+                {
+                    column: { title: 'Priority', type: 'TEXT_NUMBER' },
+                    operator: 'GREATER_THAN',
+                    values: [5]
+                },
+                {
+                    column: { title: 'Due Date', type: 'DATE' },
+                    operator: 'GREATER_THAN',
+                    values: [{ objectType: 'DATE', value: '2024-01-01' }]
+                },
+                {
+                    column: { title: 'Assigned To', type: 'CONTACT_LIST' },
+                    operator: 'EQUAL',
+                    values: [{ objectType: 'CURRENT_USER', value: '' }]
+                },
+                {
+                    column: { primary: true, type: 'TEXT_NUMBER' },
+                    operator: 'CONTAINS',
+                    values: ['PROJ-1']
+                },
+                {
+                    column: { systemColumnType: 'CREATED_BY', type: 'TEXT_NUMBER' },
+                    operator: 'NOT_EQUAL',
+                    values: ['System']
+                },
+                {
+                    column: { sheetNameColumn: true, type: 'TEXT_NUMBER' },
+                    operator: 'IS_ONE_OF',
+                    values: ['Project A', 'Project B']
+                }
+            ],
+            nestedCriteria: [
+                {
+                    operator: 'AND',
+                    criteria: [
+                        {
+                            column: { title: 'Start Date', type: 'DATE' },
+                            operator: 'LAST_N_DAYS',
+                            values: [30]
+                        },
+                        {
+                            column: { title: 'Completed', type: 'CHECKBOX' },
+                            operator: 'IS_CHECKED',
+                            values: []
+                        }
+                    ]
+                }
+            ]
+        },
+        groupingCriteria: [
+            {
+                column: { title: 'Department', type: 'PICKLIST' },
+                sortingDirection: 'ASCENDING',
+                isExpanded: true
+            },
+            {
+                column: { title: 'Priority', type: 'TEXT_NUMBER' },
+                sortingDirection: 'DESCENDING',
+                isExpanded: false
+            }
+        ],
+        summarizingCriteria: [
+            {
+                column: { title: 'Cost', type: 'TEXT_NUMBER' },
+                aggregationType: 'SUM'
+            },
+            {
+                column: { title: 'Duration', type: 'DURATION' },
+                aggregationType: 'AVG'
+            },
+            {
+                column: { title: 'Task Count', type: 'TEXT_NUMBER' },
+                aggregationType: 'COUNT'
+            }
+        ],
+        sortingCriteria: [
+            {
+                column: { title: 'Due Date', type: 'DATE' },
+                sortingDirection: 'ASCENDING'
+            },
+            {
+                column: { title: 'Priority', type: 'TEXT_NUMBER' },
+                sortingDirection: 'DESCENDING'
+            }
+        ]
+    };
+
+    it('updateReportDefinition generated url is correct', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testFilterOnlyBody,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/update-report-definition/all-response-body-properties'
+            }
+        };
+        await client.reports.updateReportDefinition(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+        const parsedUrl = new URL(matchedRequest.absoluteUrl);
+        expect(parsedUrl.pathname).toEqual(`/2.0/reports/${TEST_REPORT_ID}/definition`);
+    });
+
+    it('updateReportDefinition uses PUT method', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testFilterOnlyBody,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/update-report-definition/all-response-body-properties'
+            }
+        };
+        await client.reports.updateReportDefinition(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+        expect(matchedRequest.method).toEqual('PUT');
+    });
+
+
+    it('updateReportDefinition all response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testFilterOnlyBody,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/update-report-definition/all-response-body-properties'
+            }
+        };
+        const response = await client.reports.updateReportDefinition(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(response).toEqual({
+            message: TEST_SUCCESS_MESSAGE,
+            resultCode: TEST_SUCCESS_RESULT_CODE,
+        });
+
+        const body = JSON.parse(matchedRequest.body);
+        expect(body).toEqual(testFilterOnlyBody);
+    });
+
+    it('updateReportDefinition error 500 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testFilterOnlyBody,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/500-response'
+            }
+        };
+        try {
+            await client.reports.updateReportDefinition(options);
+            expect(true).toBe(false); // Expected an error to be thrown
+        } catch (error) {
+            expect(error.statusCode).toBe(ERROR_500_STATUS_CODE);
+            expect(error.message).toBe(ERROR_500_MESSAGE);
+        }
+    });
+
+    it('updateReportDefinition error 400 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            body: testFilterOnlyBody,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/400-response'
+            }
+        };
+        try {
+            await client.reports.updateReportDefinition(options);
+            expect(true).toBe(false); // Expected an error to be thrown
+        } catch (error) {
+            expect(error.statusCode).toBe(ERROR_400_STATUS_CODE);
+            expect(error.message).toBe(ERROR_400_MESSAGE);
+        }
+    });
+});

--- a/test/mock-api/reports/update_report_definition.spec.ts
+++ b/test/mock-api/reports/update_report_definition.spec.ts
@@ -12,7 +12,7 @@ import {
 } from './common_test_constants';
 import {
     ReportColumnType,
-    ReportSystemColumnType,
+    SystemColumnType,
     ReportFilterOperator,
     ReportFilterConditionOperator,
     ReportSortingDirection,
@@ -52,7 +52,7 @@ describe('Reports - updateReportDefinition endpoint tests', () => {
                     values: ['PROJ-1']
                 },
                 {
-                    column: { systemColumnType: ReportSystemColumnType.CREATED_BY, type: ReportColumnType.TEXT_NUMBER },
+                    column: { systemColumnType: SystemColumnType.CREATED_BY, type: ReportColumnType.TEXT_NUMBER },
                     operator: ReportFilterConditionOperator.NOT_EQUAL,
                     values: ['System']
                 },


### PR DESCRIPTION
Added support for the following endpoints

POST /2.0/reports
POST /reports/{reportId}/scope
POST /2.0/reports/{reportId}/columns
PUT /2.0/reports/{reportId}/definition
DELETE /reports/{reportId}
DELETE /reports/{reportId}/scope