### PR TITLE
feat(events): add objectIdStr field to Event interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [X.X.X] - Unreleased
 ### Added
+- Added optional `objectIdStr` field to `Event` interface to support alphanumeric object identifiers (AUD-903)
 - SDK architecte details in [ADVANCED.md](ADVANCED.md)
 - SDK testing standards in [TESTING.md](TESTING.md)
 - Added ReportsApi type to [SmartsheetClient](lib/types/SmartsheetClient.ts)

--- a/lib/events/types.ts
+++ b/lib/events/types.ts
@@ -75,6 +75,12 @@ export interface Event {
   objectId: string;
 
   /**
+   * The alphanumeric identifier of the object impacted by the event.
+   * Present for object types that use string-based identifiers.
+   */
+  objectIdStr?: string;
+
+  /**
    * Date and time of the event. Defaults to ISO-8601 format.
    * See dates and times for more information.
    */

--- a/test/mock-api/events/common_test_constants.ts
+++ b/test/mock-api/events/common_test_constants.ts
@@ -1,0 +1,44 @@
+// Common Error Status Codes
+export const ERROR_500_STATUS_CODE = 500;
+export const ERROR_500_MESSAGE = 'Internal Server Error';
+export const ERROR_400_STATUS_CODE = 400;
+export const ERROR_400_MESSAGE = 'Malformed Request';
+
+// Stream Position
+export const TEST_NEXT_STREAM_POSITION = '2.1.Y-oF8RMroSCo4WLS9p78QEz-LXzzzzzzjnXA2hFnCN_w';
+
+// Event IDs
+export const TEST_EVENT_ID_1 = '4f12345678901234';
+export const TEST_EVENT_ID_2 = '4f12345678901235';
+export const TEST_EVENT_ID_3 = '2.1.Y-oF8RMroSCo4WLS9p78QEz-LXxxxyyyjnXA2hFnCN_w';
+export const TEST_EVENT_ID_4 = '2.1.SuwpcrfUcr75nP591Hce4_zQxxxyyy_0CDfvRRx6V0';
+export const TEST_EVENT_ID_5 = '2.1.ifR6WlBin9DQVYHDkQEx1D3EAxxxyyyXtcLWa9Oio';
+
+// Object IDs (use Number() to avoid TS80008 for large integer literals)
+export const TEST_OBJECT_ID_1 = Number('1234567890123456');
+export const TEST_OBJECT_ID_2 = Number('9876543210987654');
+export const TEST_OBJECT_ID_3 = Number('3573510329814916');
+export const TEST_OBJECT_ID_4 = Number('4230707048648580');
+export const TEST_OBJECT_ID_5 = Number('8462951303303044');
+
+// Object ID strings
+export const TEST_OBJECT_ID_STR_1 = '1234567890123456';
+export const TEST_OBJECT_ID_STR_2 = '9876543210987654';
+export const TEST_OBJECT_ID_STR_3 = '3573510329814916';
+export const TEST_OBJECT_ID_STR_4 = '4230707048648580';
+export const TEST_OBJECT_ID_STR_5 = '8462951303303044';
+
+// User IDs
+export const TEST_USER_ID_1 = 12345678;
+export const TEST_USER_ID_2 = 12345679;
+export const TEST_USER_ID_3 = Number('8737233684457348');
+
+// Timestamps
+export const TEST_EVENT_TIMESTAMP_1 = '2024-05-06T10:30:00Z';
+export const TEST_EVENT_TIMESTAMP_2 = '2024-05-06T09:15:00Z';
+export const TEST_EVENT_TIMESTAMP_3 = '2024-05-06T09:09:33Z';
+export const TEST_EVENT_TIMESTAMP_4 = '2024-05-06T10:30:00Z';
+export const TEST_EVENT_TIMESTAMP_5 = '2024-05-06T10:35:15Z';
+
+// Since query parameter
+export const TEST_SINCE = '2024-05-06T00:00:00Z';

--- a/test/mock-api/events/list_events.spec.ts
+++ b/test/mock-api/events/list_events.spec.ts
@@ -1,0 +1,250 @@
+import crypto from 'crypto';
+import { createClient, findWireMockRequest } from '../utils/utils';
+import { expect } from '@jest/globals';
+import {
+  ERROR_400_MESSAGE,
+  ERROR_400_STATUS_CODE,
+  ERROR_500_MESSAGE,
+  ERROR_500_STATUS_CODE,
+  TEST_EVENT_ID_1,
+  TEST_EVENT_ID_2,
+  TEST_EVENT_ID_3,
+  TEST_EVENT_ID_4,
+  TEST_EVENT_ID_5,
+  TEST_EVENT_TIMESTAMP_1,
+  TEST_EVENT_TIMESTAMP_2,
+  TEST_EVENT_TIMESTAMP_3,
+  TEST_EVENT_TIMESTAMP_4,
+  TEST_EVENT_TIMESTAMP_5,
+  TEST_NEXT_STREAM_POSITION,
+  TEST_OBJECT_ID_1,
+  TEST_OBJECT_ID_2,
+  TEST_OBJECT_ID_3,
+  TEST_OBJECT_ID_4,
+  TEST_OBJECT_ID_5,
+  TEST_OBJECT_ID_STR_1,
+  TEST_OBJECT_ID_STR_2,
+  TEST_OBJECT_ID_STR_3,
+  TEST_OBJECT_ID_STR_4,
+  TEST_OBJECT_ID_STR_5,
+  TEST_SINCE,
+  TEST_USER_ID_1,
+  TEST_USER_ID_2,
+  TEST_USER_ID_3,
+} from './common_test_constants';
+
+describe('Events - listEvents endpoint tests', () => {
+  const client = createClient();
+
+  const expectedAllResponseProperties = {
+    moreAvailable: true,
+    nextStreamPosition: TEST_NEXT_STREAM_POSITION,
+    data: [
+      {
+        eventId: TEST_EVENT_ID_1,
+        objectType: 'SHEET',
+        objectId: TEST_OBJECT_ID_1,
+        objectIdStr: TEST_OBJECT_ID_STR_1,
+        userId: TEST_USER_ID_1,
+        requestUserId: TEST_USER_ID_1,
+        eventTimestamp: TEST_EVENT_TIMESTAMP_1,
+        action: 'UPDATE',
+        source: 'WEB_APP',
+        additionalDetails: { emailAddress: 'test@test.com' },
+      },
+      {
+        eventId: TEST_EVENT_ID_2,
+        objectType: 'WORKSPACE',
+        objectId: TEST_OBJECT_ID_2,
+        objectIdStr: TEST_OBJECT_ID_STR_2,
+        userId: TEST_USER_ID_2,
+        requestUserId: TEST_USER_ID_2,
+        eventTimestamp: TEST_EVENT_TIMESTAMP_2,
+        action: 'CREATE',
+        source: 'API_UNDEFINED_APP',
+        additionalDetails: { emailAddress: 'test@test.com' },
+      },
+      {
+        eventId: TEST_EVENT_ID_3,
+        objectType: 'SHEET',
+        action: 'PURGE',
+        objectId: TEST_OBJECT_ID_3,
+        objectIdStr: TEST_OBJECT_ID_STR_3,
+        eventTimestamp: TEST_EVENT_TIMESTAMP_3,
+        userId: TEST_USER_ID_1,
+        requestUserId: TEST_USER_ID_1,
+        source: 'UNKNOWN',
+        additionalDetails: { emailAddress: 'test@test.com' },
+      },
+      {
+        eventId: TEST_EVENT_ID_4,
+        objectType: 'ATTACHMENT',
+        action: 'CREATE',
+        objectId: TEST_OBJECT_ID_4,
+        objectIdStr: TEST_OBJECT_ID_STR_4,
+        eventTimestamp: TEST_EVENT_TIMESTAMP_4,
+        userId: TEST_USER_ID_1,
+        requestUserId: TEST_USER_ID_1,
+        source: 'UNKNOWN',
+        additionalDetails: {
+          emailAddress: 'test@test.com',
+          sheetId: '102030405',
+          attachmentName: 'picture.jpg',
+        },
+      },
+      {
+        eventId: TEST_EVENT_ID_5,
+        objectType: 'SHEET',
+        action: 'LOAD',
+        objectId: TEST_OBJECT_ID_5,
+        objectIdStr: TEST_OBJECT_ID_STR_5,
+        eventTimestamp: TEST_EVENT_TIMESTAMP_5,
+        userId: TEST_USER_ID_3,
+        requestUserId: TEST_USER_ID_3,
+        source: 'API_INTEGRATED_APP',
+        additionalDetails: { emailAddress: 'test@test.com' },
+      },
+    ],
+  };
+
+  const expectedRequiredResponseProperties = {
+    moreAvailable: false,
+    data: [
+      {
+        eventId: TEST_EVENT_ID_1,
+        objectType: 'SHEET',
+        objectId: TEST_OBJECT_ID_1,
+        userId: TEST_USER_ID_1,
+        requestUserId: TEST_USER_ID_1,
+        eventTimestamp: TEST_EVENT_TIMESTAMP_1,
+        action: 'UPDATE',
+        source: 'WEB_APP',
+      },
+      {
+        eventId: TEST_EVENT_ID_2,
+        objectType: 'WORKSPACE',
+        objectId: TEST_OBJECT_ID_2,
+        userId: TEST_USER_ID_2,
+        requestUserId: TEST_USER_ID_2,
+        eventTimestamp: TEST_EVENT_TIMESTAMP_2,
+        action: 'CREATE',
+        source: 'API_UNDEFINED_APP',
+      },
+      {
+        eventId: TEST_EVENT_ID_3,
+        objectType: 'SHEET',
+        action: 'PURGE',
+        objectId: TEST_OBJECT_ID_3,
+        eventTimestamp: TEST_EVENT_TIMESTAMP_3,
+        userId: TEST_USER_ID_1,
+        requestUserId: TEST_USER_ID_1,
+        source: 'UNKNOWN',
+      },
+      {
+        eventId: TEST_EVENT_ID_4,
+        objectType: 'ATTACHMENT',
+        action: 'CREATE',
+        objectId: TEST_OBJECT_ID_4,
+        eventTimestamp: TEST_EVENT_TIMESTAMP_4,
+        userId: TEST_USER_ID_1,
+        requestUserId: TEST_USER_ID_1,
+        source: 'UNKNOWN',
+      },
+      {
+        eventId: TEST_EVENT_ID_5,
+        objectType: 'SHEET',
+        action: 'LOAD',
+        objectId: TEST_OBJECT_ID_5,
+        eventTimestamp: TEST_EVENT_TIMESTAMP_5,
+        userId: TEST_USER_ID_3,
+        requestUserId: TEST_USER_ID_3,
+        source: 'API_INTEGRATED_APP',
+      },
+    ],
+  };
+
+  it('getEvents generated url is correct', async () => {
+    const requestId = crypto.randomUUID();
+    const options = {
+      queryParameters: {
+        since: TEST_SINCE,
+      },
+      customProperties: {
+        'x-request-id': requestId,
+        'x-test-name': '/events/list-events/all-response-body-properties',
+      },
+    };
+    await client.events.getEvents(options);
+    const matchedRequest = await findWireMockRequest(requestId);
+    const parsedUrl = new URL(matchedRequest.absoluteUrl);
+    expect(parsedUrl.pathname).toEqual('/2.0/events');
+    expect(matchedRequest.method).toEqual('GET');
+
+    const queryParamsObject = Object.fromEntries(parsedUrl.searchParams);
+    expect(queryParamsObject).toEqual({ since: TEST_SINCE });
+  });
+
+  it('getEvents all response body properties', async () => {
+    const requestId = crypto.randomUUID();
+    const options = {
+      customProperties: {
+        'x-request-id': requestId,
+        'x-test-name': '/events/list-events/all-response-body-properties',
+      },
+    };
+    const response = await client.events.getEvents(options);
+    const matchedRequest = await findWireMockRequest(requestId);
+
+    expect(matchedRequest.body).toEqual('');
+    expect(response).toEqual(expectedAllResponseProperties);
+  });
+
+  it('getEvents required response body properties', async () => {
+    const requestId = crypto.randomUUID();
+    const options = {
+      customProperties: {
+        'x-request-id': requestId,
+        'x-test-name': '/events/list-events/required-response-body-properties',
+      },
+    };
+    const response = await client.events.getEvents(options);
+    const matchedRequest = await findWireMockRequest(requestId);
+
+    expect(matchedRequest.body).toEqual('');
+    expect(response).toEqual(expectedRequiredResponseProperties);
+  });
+
+  it('getEvents error 400 response', async () => {
+    const requestId = crypto.randomUUID();
+    const options = {
+      customProperties: {
+        'x-request-id': requestId,
+        'x-test-name': '/errors/400-response',
+      },
+    };
+    try {
+      await client.events.getEvents(options);
+      expect(true).toBe(false); // Expected an error to be thrown
+    } catch (error: any) {
+      expect(error.statusCode).toBe(ERROR_400_STATUS_CODE);
+      expect(error.message).toBe(ERROR_400_MESSAGE);
+    }
+  });
+
+  it('getEvents error 500 response', async () => {
+    const requestId = crypto.randomUUID();
+    const options = {
+      customProperties: {
+        'x-request-id': requestId,
+        'x-test-name': '/errors/500-response',
+      },
+    };
+    try {
+      await client.events.getEvents(options);
+      expect(true).toBe(false); // Expected an error to be thrown
+    } catch (error: any) {
+      expect(error.statusCode).toBe(ERROR_500_STATUS_CODE);
+      expect(error.message).toBe(ERROR_500_MESSAGE);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
 
Adds the optional `objectIdStr` field to the `Event` interface in the Smartsheet JavaScript SDK to support alphanumeric object identifiers. This mirrors the implementation already done in [smartsheet-java-sdk](https://github.com/smartsheet/smartsheet-java-sdk).
 
## Changes
 
- Added `objectIdStr?: string` to the `Event` interface in `lib/events/types.ts` with JSDoc documentation
- Added WireMock integration tests for the `getEvents` endpoint (`test/mock-api/events/`)
- Updated `CHANGELOG.md`
## Testing
 
WireMock integration tests cover:
- URL and query parameter correctness
- Full response body (with `objectIdStr`)
- Required-only response body (without `objectIdStr`, confirming backward compatibility)
- 400 and 500 error handling
Start WireMock (`docker compose up` in `smartsheet-sdk-tests`), then run:
```
npm test -- test/mock-api/events/list_events.spec.ts
```