### PR TITLE
Add support for the path endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [X.X.X] - Unreleased
 
+### Added
+
+- Added support for GET /2.0/sheets/{sheetId}/path endpoint (`getSheetPath`)
+- Added support for GET /2.0/reports/{reportId}/path endpoint (`getReportPath`)
+- Added support for GET /2.0/sights/{sightId}/path endpoint (`getSightPath`)
+- Added support for GET /2.0/folders/{folderId}/path endpoint (`getFolderPath`)
+- Added helper functions `getLeaf<Asset>()` and `getLeaf<Asset>Path()` for convenient traversal of the path node objects
+
 ## [5.0.1] - 2026-06-10
 
 ### Fixed

--- a/lib/folders/helpers.ts
+++ b/lib/folders/helpers.ts
@@ -1,0 +1,45 @@
+import type { FolderPathNode } from './types';
+
+/**
+ * Returns the deepest {@link FolderPathNode} (the target folder).
+ * Use this for quick access to the leaf folder object from a path response.
+ *
+ * @param node - The root {@link FolderPathNode} returned by `getFolderPath`
+ * @returns The deepest (leaf) {@link FolderPathNode}
+ *
+ * @example
+ * ```typescript
+ * const path = await client.folders.getFolderPath({ folderId: 7116448184199044 });
+ * const leaf = getLeafFolder(path);
+ * console.log(leaf.name);
+ * ```
+ */
+export function getLeafFolder(node: FolderPathNode): FolderPathNode {
+  if (node.folders && node.folders.length > 0) {
+    return getLeafFolder(node.folders[0]);
+  }
+
+  return node;
+}
+
+/**
+ * Returns a Unix-like slash-separated path string from the given node to the target folder.
+ * Use this for quick access to the full path string of the leaf folder from a path response.
+ *
+ * @param node - The root {@link FolderPathNode} returned by `getFolderPath`
+ * @returns A slash-separated path string
+ *
+ * @example
+ * ```typescript
+ * const path = await client.folders.getFolderPath({ folderId: 7116448184199044 });
+ * const pathStr = getLeafFolderPath(path);
+ * console.log(pathStr); // '/Workspace/Folder/Subfolder'
+ * ```
+ */
+export function getLeafFolderPath(node: FolderPathNode): string {
+  if (node.folders && node.folders.length > 0) {
+    return `/${node.name}${getLeafFolderPath(node.folders[0])}`;
+  }
+
+  return `/${node.name}`;
+}

--- a/lib/folders/index.ts
+++ b/lib/folders/index.ts
@@ -19,7 +19,7 @@ import type {
   CopyFolderResponse,
   GetFolderPathOptions,
 } from './types';
-import { FolderPathNode } from './types';
+import type { FolderPathNode } from './types';
 
 export function create(options: CreateOptions): FoldersApi {
   const requestor = options.requestor;
@@ -93,10 +93,9 @@ export function create(options: CreateOptions): FoldersApi {
     const urlOptions = { url: options.apiUrls.folders + '/' + getOptions.folderId + '/path' };
     return requestor
       .get({ ...optionsToSend, ...urlOptions, ...getOptions })
-      .then((data: Record<string, unknown>) => {
-        const node = new FolderPathNode(data);
-        if (callback) callback(undefined, node);
-        return node;
+      .then((data: FolderPathNode) => {
+        if (callback) callback(undefined, data);
+        return data;
       })
       .catch((err: unknown) => {
         if (callback) callback(err as ApiError, undefined);

--- a/lib/folders/index.ts
+++ b/lib/folders/index.ts
@@ -1,3 +1,4 @@
+import type { ApiError } from '../types/ApiError';
 import type { CreateOptions } from '../types/CreateOptions';
 import type { RequestCallback } from '../types/RequestCallback';
 import type { BaseResponseStatus } from '../types/BaseResponseStatus';
@@ -16,7 +17,9 @@ import type {
   MoveFolderOptions,
   MoveFolderResponse,
   CopyFolderResponse,
+  GetFolderPathOptions,
 } from './types';
+import { FolderPathNode } from './types';
 
 export function create(options: CreateOptions): FoldersApi {
   const requestor = options.requestor;
@@ -83,6 +86,24 @@ export function create(options: CreateOptions): FoldersApi {
     return requestor.get({ ...optionsToSend, ...urlOptions, ...getOptions }, callback);
   };
 
+  const getFolderPath = (
+    getOptions: GetFolderPathOptions,
+    callback?: RequestCallback<FolderPathNode>
+  ): Promise<FolderPathNode> => {
+    const urlOptions = { url: options.apiUrls.folders + '/' + getOptions.folderId + '/path' };
+    return requestor
+      .get({ ...optionsToSend, ...urlOptions, ...getOptions })
+      .then((data: Record<string, unknown>) => {
+        const node = new FolderPathNode(data);
+        if (callback) callback(undefined, node);
+        return node;
+      })
+      .catch((err: unknown) => {
+        if (callback) callback(err as ApiError, undefined);
+        return Promise.reject(err);
+      });
+  };
+
   return {
     getFolderMetadata,
     getFolderChildren,
@@ -91,5 +112,6 @@ export function create(options: CreateOptions): FoldersApi {
     deleteFolder,
     moveFolder,
     copyFolder,
+    getFolderPath,
   };
 }

--- a/lib/folders/index.ts
+++ b/lib/folders/index.ts
@@ -1,4 +1,3 @@
-import type { ApiError } from '../types/ApiError';
 import type { CreateOptions } from '../types/CreateOptions';
 import type { RequestCallback } from '../types/RequestCallback';
 import type { BaseResponseStatus } from '../types/BaseResponseStatus';
@@ -91,16 +90,7 @@ export function create(options: CreateOptions): FoldersApi {
     callback?: RequestCallback<FolderPathNode>
   ): Promise<FolderPathNode> => {
     const urlOptions = { url: options.apiUrls.folders + '/' + getOptions.folderId + '/path' };
-    return requestor
-      .get({ ...optionsToSend, ...urlOptions, ...getOptions })
-      .then((data: FolderPathNode) => {
-        if (callback) callback(undefined, data);
-        return data;
-      })
-      .catch((err: unknown) => {
-        if (callback) callback(err as ApiError, undefined);
-        return Promise.reject(err);
-      });
+    return requestor.get({ ...optionsToSend, ...urlOptions, ...getOptions }, callback);
   };
 
   return {

--- a/lib/folders/types.ts
+++ b/lib/folders/types.ts
@@ -2,6 +2,7 @@ import type { RequestCallback } from '../types/RequestCallback';
 import type { RequestOptions } from '../types/RequestOptions';
 import type { BaseResponseStatus } from '../types/BaseResponseStatus';
 import type { FailedItem } from '../types/FailedItem';
+import { APIAccessLevel } from '@smartsheet/types';
 
 // ============================================================================
 // Folders API Interface
@@ -740,27 +741,18 @@ export interface MoveFolderResponse extends BaseResponseStatus {
 // Get Folder Path
 // ============================================================================
 
-export interface PathLeaf {
-  id: number;
-  name?: string;
-  permalink?: string;
-  accessLevel?: string;
-  createdAt?: string;
-  modifiedAt?: string;
-}
-
 export class FolderPathNode {
   id: number;
-  name?: string;
-  permalink?: string;
-  accessLevel?: string;
+  name: string;
+  permalink: string;
+  accessLevel?: APIAccessLevel;
   folders?: FolderPathNode[];
 
   constructor(data: Record<string, unknown>) {
     this.id = data.id as number;
-    this.name = data.name as string | undefined;
-    this.permalink = data.permalink as string | undefined;
-    this.accessLevel = data.accessLevel as string | undefined;
+    this.name = data.name as string;
+    this.permalink = data.permalink as string;
+    this.accessLevel = data.accessLevel as APIAccessLevel | undefined;
     if (Array.isArray(data.folders)) {
       this.folders = (data.folders as Record<string, unknown>[]).map((f) => new FolderPathNode(f));
     }

--- a/lib/folders/types.ts
+++ b/lib/folders/types.ts
@@ -741,36 +741,24 @@ export interface MoveFolderResponse extends BaseResponseStatus {
 // Get Folder Path
 // ============================================================================
 
+/**
+ * Represents a node in the path tree from the workspace root to the target folder.
+ * Returned by `getFolderPath`. Use {@link getLeafFolder} to extract the deepest folder object,
+ * or {@link getLeafFolderPath} to get the full slash-separated path string.
+ *
+ * @see getLeafFolder
+ * @see getLeafFolderPath
+ */
 export interface FolderPathNode extends PathNode {
   folders?: FolderPathNode[];
 }
 
 /**
- * Returns the deepest {@link FolderPathNode} (the target folder).
- * Use this for quick access to the leaf folder object from a path response.
- */
-export function getLeafFolder(node: FolderPathNode): FolderPathNode {
-  if (node.folders && node.folders.length > 0) {
-    return getLeafFolder(node.folders[0]);
-  }
-
-  return node;
-}
-
-/**
- * Returns a Unix-like slash-separated path string from the given node to the target folder.
- * Use this for quick access to the full path string of the leaf folder from a path response.
+ * Options for getting the path from the workspace root to the specified folder.
  *
- * @example '/Workspace/Folder/Subfolder'
+ * @remarks
+ * It mirrors to the following Smartsheet REST API method: `GET /folders/{folderId}/path`
  */
-export function getLeafFolderPath(node: FolderPathNode): string {
-  if (node.folders && node.folders.length > 0) {
-    return `/${node.name}${getLeafFolderPath(node.folders[0])}`;
-  }
-
-  return `/${node.name}`;
-}
-
 export interface GetFolderPathOptions extends RequestOptions<undefined, undefined> {
   /**
    * Folder Id.

--- a/lib/folders/types.ts
+++ b/lib/folders/types.ts
@@ -2,7 +2,7 @@ import type { RequestCallback } from '../types/RequestCallback';
 import type { RequestOptions } from '../types/RequestOptions';
 import type { BaseResponseStatus } from '../types/BaseResponseStatus';
 import type { FailedItem } from '../types/FailedItem';
-import { APIAccessLevel } from '@smartsheet/types';
+import type { APIAccessLevel } from '@smartsheet/types';
 
 // ============================================================================
 // Folders API Interface

--- a/lib/folders/types.ts
+++ b/lib/folders/types.ts
@@ -2,7 +2,7 @@ import type { RequestCallback } from '../types/RequestCallback';
 import type { RequestOptions } from '../types/RequestOptions';
 import type { BaseResponseStatus } from '../types/BaseResponseStatus';
 import type { FailedItem } from '../types/FailedItem';
-import type { APIAccessLevel } from '@smartsheet/types';
+import type { APIAccessLevel } from '../types/ApiAccessLevel';
 
 // ============================================================================
 // Folders API Interface

--- a/lib/folders/types.ts
+++ b/lib/folders/types.ts
@@ -196,6 +196,28 @@ export interface FoldersApi {
     options: MoveFolderOptions,
     callback?: RequestCallback<MoveFolderResponse>
   ) => Promise<MoveFolderResponse>;
+
+  /**
+   * Gets the path from the workspace root to the specified folder.
+   *
+   * @param options - {@link GetFolderPathOptions} - Configuration options for the request
+   * @param callback - {@link RequestCallback}\<{@link FolderPathNode}\> - Optional callback function
+   * @returns Promise\<{@link FolderPathNode}\>
+   *
+   * @remarks
+   * It mirrors to the following Smartsheet REST API method: `GET /folders/{folderId}/path`
+   *
+   * @example
+   * ```typescript
+   * const path = await client.folders.getFolderPath({
+   *   folderId: 7116448184199044
+   * });
+   * ```
+   */
+  getFolderPath: (
+    options: GetFolderPathOptions,
+    callback?: RequestCallback<FolderPathNode>
+  ) => Promise<FolderPathNode>;
 }
 
 // ============================================================================
@@ -715,4 +737,64 @@ export interface MoveFolderResponse extends BaseResponseStatus {
    * The moved folder object.
    */
   result: Folder;
+}
+
+// ============================================================================
+// Get Folder Path
+// ============================================================================
+
+export interface PathLeaf {
+  id: number;
+  name?: string;
+  permalink?: string;
+  accessLevel?: string;
+  createdAt?: string;
+  modifiedAt?: string;
+}
+
+export class FolderPathNode {
+  id: number;
+  name?: string;
+  permalink?: string;
+  accessLevel?: string;
+  folders?: FolderPathNode[];
+
+  constructor(data: Record<string, unknown>) {
+    this.id = data.id as number;
+    this.name = data.name as string | undefined;
+    this.permalink = data.permalink as string | undefined;
+    this.accessLevel = data.accessLevel as string | undefined;
+    if (Array.isArray(data.folders)) {
+      this.folders = (data.folders as Record<string, unknown>[]).map((f) => new FolderPathNode(f));
+    }
+  }
+
+  private _walkToLeaf(): FolderPathNode[] {
+    if (this.folders && this.folders.length > 0) {
+      return [this, ...this.folders[0]._walkToLeaf()];
+    }
+    return [this];
+  }
+
+  /** Returns the deepest FolderPathNode (the target folder). */
+  getFolder(): FolderPathNode {
+    const nodes = this._walkToLeaf();
+    return nodes[nodes.length - 1];
+  }
+
+  /** Returns a slash-separated path string of folder names from this node to the target folder. */
+  getFolderPath(): string {
+    const nodes = this._walkToLeaf();
+    return nodes
+      .map((n) => n.name)
+      .filter(Boolean)
+      .join('/');
+  }
+}
+
+export interface GetFolderPathOptions extends RequestOptions<undefined, undefined> {
+  /**
+   * Folder Id.
+   */
+  folderId: number;
 }

--- a/lib/folders/types.ts
+++ b/lib/folders/types.ts
@@ -758,26 +758,26 @@ export class FolderPathNode {
     }
   }
 
-  private _walkToLeaf(): FolderPathNode[] {
-    if (this.folders && this.folders.length > 0) {
-      return [this, ...this.folders[0]._walkToLeaf()];
-    }
-    return [this];
-  }
-
   /** Returns the deepest FolderPathNode (the target folder). */
-  getFolder(): FolderPathNode {
-    const nodes = this._walkToLeaf();
-    return nodes[nodes.length - 1];
+  getLeafFolder(): FolderPathNode {
+    if (this.folders && this.folders.length > 0) {
+      return this.folders[0].getLeafFolder();
+    }
+
+    return this;
   }
 
-  /** Returns a slash-separated path string of folder names from this node to the target folder. */
-  getFolderPath(): string {
-    const nodes = this._walkToLeaf();
-    return nodes
-      .map((n) => n.name)
-      .filter(Boolean)
-      .join('/');
+  /**
+   * Returns a Unix-like slash-separated path string from this node to the target folder.
+   *
+   * @example '/Workspace/Folder/Subfolder'
+   **/
+  getLeafFolderPath(): string {
+    if (this.folders && this.folders.length > 0) {
+      return `/${this.name}${this.folders[0].getLeafFolderPath()}`;
+    }
+
+    return `/${this.name}`;
   }
 }
 

--- a/lib/folders/types.ts
+++ b/lib/folders/types.ts
@@ -214,10 +214,7 @@ export interface FoldersApi {
    * });
    * ```
    */
-  getFolderPath: (
-    options: GetFolderPathOptions,
-    callback?: RequestCallback<FolderPathNode>
-  ) => Promise<FolderPathNode>;
+  getFolderPath: (options: GetFolderPathOptions, callback?: RequestCallback<FolderPathNode>) => Promise<FolderPathNode>;
 }
 
 // ============================================================================

--- a/lib/folders/types.ts
+++ b/lib/folders/types.ts
@@ -2,7 +2,7 @@ import type { RequestCallback } from '../types/RequestCallback';
 import type { RequestOptions } from '../types/RequestOptions';
 import type { BaseResponseStatus } from '../types/BaseResponseStatus';
 import type { FailedItem } from '../types/FailedItem';
-import type { APIAccessLevel } from '../types/ApiAccessLevel';
+import type { PathNode } from '../types/PathNode';
 
 // ============================================================================
 // Folders API Interface
@@ -741,44 +741,34 @@ export interface MoveFolderResponse extends BaseResponseStatus {
 // Get Folder Path
 // ============================================================================
 
-export class FolderPathNode {
-  id: number;
-  name: string;
-  permalink: string;
-  accessLevel?: APIAccessLevel;
+export interface FolderPathNode extends PathNode {
   folders?: FolderPathNode[];
+}
 
-  constructor(data: Record<string, unknown>) {
-    this.id = data.id as number;
-    this.name = data.name as string;
-    this.permalink = data.permalink as string;
-    this.accessLevel = data.accessLevel as APIAccessLevel | undefined;
-    if (Array.isArray(data.folders)) {
-      this.folders = (data.folders as Record<string, unknown>[]).map((f) => new FolderPathNode(f));
-    }
+/**
+ * Returns the deepest {@link FolderPathNode} (the target folder).
+ * Use this for quick access to the leaf folder object from a path response.
+ */
+export function getLeafFolder(node: FolderPathNode): FolderPathNode {
+  if (node.folders && node.folders.length > 0) {
+    return getLeafFolder(node.folders[0]);
   }
 
-  /** Returns the deepest FolderPathNode (the target folder). */
-  getLeafFolder(): FolderPathNode {
-    if (this.folders && this.folders.length > 0) {
-      return this.folders[0].getLeafFolder();
-    }
+  return node;
+}
 
-    return this;
+/**
+ * Returns a Unix-like slash-separated path string from the given node to the target folder.
+ * Use this for quick access to the full path string of the leaf folder from a path response.
+ *
+ * @example '/Workspace/Folder/Subfolder'
+ */
+export function getLeafFolderPath(node: FolderPathNode): string {
+  if (node.folders && node.folders.length > 0) {
+    return `/${node.name}${getLeafFolderPath(node.folders[0])}`;
   }
 
-  /**
-   * Returns a Unix-like slash-separated path string from this node to the target folder.
-   *
-   * @example '/Workspace/Folder/Subfolder'
-   **/
-  getLeafFolderPath(): string {
-    if (this.folders && this.folders.length > 0) {
-      return `/${this.name}${this.folders[0].getLeafFolderPath()}`;
-    }
-
-    return `/${this.name}`;
-  }
+  return `/${node.name}`;
 }
 
 export interface GetFolderPathOptions extends RequestOptions<undefined, undefined> {

--- a/lib/reports/helpers.ts
+++ b/lib/reports/helpers.ts
@@ -1,0 +1,54 @@
+import type { PathLeaf } from '../types/PathLeaf';
+import type { ReportPathNode } from './types';
+
+/**
+ * Returns the target {@link PathLeaf} report, or undefined if not reachable.
+ * Use this for quick access to the leaf report object from a path response.
+ *
+ * @param node - The root {@link ReportPathNode} returned by `getReportPath`
+ * @returns The leaf {@link PathLeaf} report, or `undefined` if not found
+ *
+ * @example
+ * ```typescript
+ * const path = await client.reports.getReportPath({ reportId: 4583173393803140 });
+ * const leaf = getLeafReport(path);
+ * console.log(leaf?.name);
+ * ```
+ */
+export function getLeafReport(node: ReportPathNode): PathLeaf | undefined {
+  if (node.reports && node.reports.length > 0) {
+    return node.reports[0];
+  }
+
+  if (node.folders && node.folders.length > 0) {
+    return getLeafReport(node.folders[0]);
+  }
+
+  return undefined;
+}
+
+/**
+ * Returns a Unix-like slash-separated path string from the given node to the target report.
+ * Use this for quick access to the full path string of the leaf report from a path response.
+ *
+ * @param node - The root {@link ReportPathNode} returned by `getReportPath`
+ * @returns A slash-separated path string, or `undefined` if not reachable
+ *
+ * @example
+ * ```typescript
+ * const path = await client.reports.getReportPath({ reportId: 4583173393803140 });
+ * const pathStr = getLeafReportPath(path);
+ * console.log(pathStr); // '/Workspace/Folder/Report'
+ * ```
+ */
+export function getLeafReportPath(node: ReportPathNode): string | undefined {
+  if (node.reports && node.reports.length > 0) {
+    return `/${node.reports[0].name}`;
+  }
+
+  if (node.folders && node.folders.length > 0) {
+    return `/${node.name}${getLeafReportPath(node.folders[0])}`;
+  }
+
+  return undefined;
+}

--- a/lib/reports/index.ts
+++ b/lib/reports/index.ts
@@ -28,7 +28,7 @@ import type {
   CreateReportResponse,
   GetReportPathOptions,
 } from './types';
-import { ReportPathNode } from './types';
+import type { ReportPathNode } from './types';
 import * as constants from '../utils/constants';
 
 export function create(options: CreateOptions): ReportsApi {
@@ -150,10 +150,9 @@ export function create(options: CreateOptions): ReportsApi {
     const urlOptions = { url: options.apiUrls.reports + '/' + getOptions.reportId + '/path' };
     return requestor
       .get({ ...optionsToSend, ...urlOptions, ...getOptions })
-      .then((data: Record<string, unknown>) => {
-        const node = new ReportPathNode(data);
-        if (callback) callback(undefined, node);
-        return node;
+      .then((data: ReportPathNode) => {
+        if (callback) callback(undefined, data);
+        return data;
       })
       .catch((err: unknown) => {
         if (callback) callback(err as ApiError, undefined);

--- a/lib/reports/index.ts
+++ b/lib/reports/index.ts
@@ -1,3 +1,4 @@
+import type { ApiError } from '../types/ApiError';
 import type { BaseResponseStatus } from '../types/BaseResponseStatus';
 import type { CreateOptions } from '../types/CreateOptions';
 import type { RequestCallback } from '../types/RequestCallback';
@@ -25,7 +26,9 @@ import type {
   AddReportColumnsResponse,
   CreateReportOptions,
   CreateReportResponse,
+  GetReportPathOptions,
 } from './types';
+import { ReportPathNode } from './types';
 import * as constants from '../utils/constants';
 
 export function create(options: CreateOptions): ReportsApi {
@@ -140,6 +143,24 @@ export function create(options: CreateOptions): ReportsApi {
     return requestor.post({ ...optionsToSend, ...urlOptions, ...postOptions }, callback);
   };
 
+  const getReportPath = (
+    getOptions: GetReportPathOptions,
+    callback?: RequestCallback<ReportPathNode>
+  ): Promise<ReportPathNode> => {
+    const urlOptions = { url: options.apiUrls.reports + '/' + getOptions.reportId + '/path' };
+    return requestor
+      .get({ ...optionsToSend, ...urlOptions, ...getOptions })
+      .then((data: Record<string, unknown>) => {
+        const node = new ReportPathNode(data);
+        if (callback) callback(undefined, node);
+        return node;
+      })
+      .catch((err: unknown) => {
+        if (callback) callback(err as ApiError, undefined);
+        return Promise.reject(err);
+      });
+  };
+
   return {
     listReports,
     getReport,
@@ -154,5 +175,6 @@ export function create(options: CreateOptions): ReportsApi {
     removeReportScope,
     addReportColumns,
     createReport,
+    getReportPath,
   };
 }

--- a/lib/reports/index.ts
+++ b/lib/reports/index.ts
@@ -1,4 +1,3 @@
-import type { ApiError } from '../types/ApiError';
 import type { BaseResponseStatus } from '../types/BaseResponseStatus';
 import type { CreateOptions } from '../types/CreateOptions';
 import type { RequestCallback } from '../types/RequestCallback';
@@ -148,16 +147,7 @@ export function create(options: CreateOptions): ReportsApi {
     callback?: RequestCallback<ReportPathNode>
   ): Promise<ReportPathNode> => {
     const urlOptions = { url: options.apiUrls.reports + '/' + getOptions.reportId + '/path' };
-    return requestor
-      .get({ ...optionsToSend, ...urlOptions, ...getOptions })
-      .then((data: ReportPathNode) => {
-        if (callback) callback(undefined, data);
-        return data;
-      })
-      .catch((err: unknown) => {
-        if (callback) callback(err as ApiError, undefined);
-        return Promise.reject(err);
-      });
+    return requestor.get({ ...optionsToSend, ...urlOptions, ...getOptions }, callback);
   };
 
   return {

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -11,7 +11,7 @@ import type { CrossSheetReference } from '../cross-sheet-references/types';
 import type { SheetSummary } from '../sheet-summary/types';
 import type { SheetUserSettings } from '../sheets/types';
 import type { WorkspaceListing } from '../workspaces/types';
-import type { APIAccessLevel } from '@smartsheet/types';
+import type { APIAccessLevel } from '../types/ApiAccessLevel';
 
 // ============================================================================
 // Reports API Interface

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -1686,32 +1686,34 @@ export class ReportPathNode {
     }
   }
 
-  private _walkToLeaf(): ReportPathNode[] {
-    if (this.reports && this.reports.length > 0) return [this];
-    if (this.folders && this.folders.length > 0) {
-      return [this, ...this.folders[0]._walkToLeaf()];
-    }
-    return [this];
-  }
-
   /** Returns the target PathLeaf report, or undefined if not reachable. */
-  getReport(): PathLeaf | undefined {
-    for (const node of this._walkToLeaf()) {
-      if (node.reports && node.reports.length > 0) return node.reports[0];
+  getLeafReport(): PathLeaf | undefined {
+    if (this.reports && this.reports.length > 0) {
+      return this.reports[0];
     }
+
+    if (this.folders && this.folders.length > 0) {
+      return this.folders[0].getLeafReport();
+    }
+
     return undefined;
   }
 
-  /** Returns a slash-separated path string from this node to the target report. */
-  getReportPath(): string | undefined {
-    const nodes = this._walkToLeaf();
-    if (nodes.length === 0) return undefined;
-    const parts = nodes.map((n) => n.name).filter(Boolean) as string[];
-    const leaf = nodes[nodes.length - 1];
-    if (leaf.reports && leaf.reports.length > 0 && leaf.reports[0].name) {
-      parts[parts.length - 1] = leaf.reports[0].name;
+  /**
+   * Returns a Unix-like slash-separated path string from this node to the target report.
+   *
+   * @example '/Workspace/Folder/Report'
+   **/
+  getLeafReportPath(): string | undefined {
+    if (this.reports && this.reports.length > 0) {
+      return `/${this.reports[0].name}`;
     }
-    return parts.length > 0 ? parts.join('/') : undefined;
+
+    if (this.folders && this.folders.length > 0) {
+      return `/${this.name}${this.folders[0].getLeafReportPath()}`;
+    }
+
+    return undefined;
   }
 }
 

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -430,6 +430,28 @@ export interface ReportsApi {
     options: CreateReportOptions,
     callback?: RequestCallback<CreateReportResponse>
   ) => Promise<CreateReportResponse>;
+
+  /**
+   * Gets the path from the workspace root to the specified report.
+   *
+   * @param options - {@link GetReportPathOptions} - Configuration options for the request
+   * @param callback - {@link RequestCallback}\<{@link ReportPathNode}\> - Optional callback function
+   * @returns Promise\<{@link ReportPathNode}\>
+   *
+   * @remarks
+   * It mirrors to the following Smartsheet REST API method: `GET /reports/{reportId}/path`
+   *
+   * @example
+   * ```typescript
+   * const path = await client.reports.getReportPath({
+   *   reportId: 4583173393803140
+   * });
+   * ```
+   */
+  getReportPath: (
+    options: GetReportPathOptions,
+    callback?: RequestCallback<ReportPathNode>
+  ) => Promise<ReportPathNode>;
 }
 
 // ============================================================================
@@ -1638,4 +1660,74 @@ export interface CreateReportResponse extends BaseResponseStatus {
    * The created report details.
    */
   result: CreateReportResult;
+}
+
+// ============================================================================
+// Get Report Path
+// ============================================================================
+
+export interface PathLeaf {
+  id: number;
+  name?: string;
+  permalink?: string;
+  accessLevel?: string;
+  createdAt?: string;
+  modifiedAt?: string;
+}
+
+export class ReportPathNode {
+  id: number;
+  name?: string;
+  permalink?: string;
+  accessLevel?: string;
+  folders?: ReportPathNode[];
+  reports?: PathLeaf[];
+
+  constructor(data: Record<string, unknown>) {
+    this.id = data.id as number;
+    this.name = data.name as string | undefined;
+    this.permalink = data.permalink as string | undefined;
+    this.accessLevel = data.accessLevel as string | undefined;
+    if (Array.isArray(data.folders)) {
+      this.folders = (data.folders as Record<string, unknown>[]).map((f) => new ReportPathNode(f));
+    }
+    if (Array.isArray(data.reports)) {
+      this.reports = data.reports as PathLeaf[];
+    }
+  }
+
+  private _walkToLeaf(): ReportPathNode[] {
+    if (this.reports && this.reports.length > 0) return [this];
+    if (this.folders && this.folders.length > 0) {
+      return [this, ...this.folders[0]._walkToLeaf()];
+    }
+    return [this];
+  }
+
+  /** Returns the target PathLeaf report, or undefined if not reachable. */
+  getReport(): PathLeaf | undefined {
+    for (const node of this._walkToLeaf()) {
+      if (node.reports && node.reports.length > 0) return node.reports[0];
+    }
+    return undefined;
+  }
+
+  /** Returns a slash-separated path string from this node to the target report. */
+  getReportPath(): string | undefined {
+    const nodes = this._walkToLeaf();
+    if (nodes.length === 0) return undefined;
+    const parts = nodes.map((n) => n.name).filter(Boolean) as string[];
+    const leaf = nodes[nodes.length - 1];
+    if (leaf.reports && leaf.reports.length > 0 && leaf.reports[0].name) {
+      parts[parts.length - 1] = leaf.reports[0].name;
+    }
+    return parts.length > 0 ? parts.join('/') : undefined;
+  }
+}
+
+export interface GetReportPathOptions extends RequestOptions<undefined, undefined> {
+  /**
+   * Report Id.
+   */
+  reportId: number;
 }

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -1665,45 +1665,25 @@ export interface CreateReportResponse extends BaseResponseStatus {
 // Get Report Path
 // ============================================================================
 
+/**
+ * Represents a node in the path tree from the workspace root to the target report.
+ * Returned by `getReportPath`. Use {@link getLeafReport} to extract the leaf report object,
+ * or {@link getLeafReportPath} to get the full slash-separated path string.
+ *
+ * @see getLeafReport
+ * @see getLeafReportPath
+ */
 export interface ReportPathNode extends PathNode {
   folders?: ReportPathNode[];
   reports?: PathLeaf[];
 }
 
 /**
- * Returns the target {@link PathLeaf} report, or undefined if not reachable.
- * Use this for quick access to the leaf report object from a path response.
- */
-export function getLeafReport(node: ReportPathNode): PathLeaf | undefined {
-  if (node.reports && node.reports.length > 0) {
-    return node.reports[0];
-  }
-
-  if (node.folders && node.folders.length > 0) {
-    return getLeafReport(node.folders[0]);
-  }
-
-  return undefined;
-}
-
-/**
- * Returns a Unix-like slash-separated path string from the given node to the target report.
- * Use this for quick access to the full path string of the leaf report from a path response.
+ * Options for getting the path from the workspace root to the specified report.
  *
- * @example '/Workspace/Folder/Report'
+ * @remarks
+ * It mirrors to the following Smartsheet REST API method: `GET /reports/{reportId}/path`
  */
-export function getLeafReportPath(node: ReportPathNode): string | undefined {
-  if (node.reports && node.reports.length > 0) {
-    return `/${node.reports[0].name}`;
-  }
-
-  if (node.folders && node.folders.length > 0) {
-    return `/${node.name}${getLeafReportPath(node.folders[0])}`;
-  }
-
-  return undefined;
-}
-
 export interface GetReportPathOptions extends RequestOptions<undefined, undefined> {
   /**
    * Report Id.

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -448,10 +448,7 @@ export interface ReportsApi {
    * });
    * ```
    */
-  getReportPath: (
-    options: GetReportPathOptions,
-    callback?: RequestCallback<ReportPathNode>
-  ) => Promise<ReportPathNode>;
+  getReportPath: (options: GetReportPathOptions, callback?: RequestCallback<ReportPathNode>) => Promise<ReportPathNode>;
 }
 
 // ============================================================================

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -1,3 +1,4 @@
+import type { PathLeaf } from '../types/PathLeaf';
 import type { RequestCallback } from '../types/RequestCallback';
 import type { RequestOptions } from '../types/RequestOptions';
 import type { BaseResponseStatus } from '../types/BaseResponseStatus';
@@ -10,6 +11,7 @@ import type { CrossSheetReference } from '../cross-sheet-references/types';
 import type { SheetSummary } from '../sheet-summary/types';
 import type { SheetUserSettings } from '../sheets/types';
 import type { WorkspaceListing } from '../workspaces/types';
+import { APIAccessLevel } from '@smartsheet/types';
 
 // ============================================================================
 // Reports API Interface
@@ -1663,28 +1665,19 @@ export interface CreateReportResponse extends BaseResponseStatus {
 // Get Report Path
 // ============================================================================
 
-export interface PathLeaf {
-  id: number;
-  name?: string;
-  permalink?: string;
-  accessLevel?: string;
-  createdAt?: string;
-  modifiedAt?: string;
-}
-
 export class ReportPathNode {
   id: number;
-  name?: string;
-  permalink?: string;
-  accessLevel?: string;
+  name: string;
+  permalink: string;
+  accessLevel?: APIAccessLevel;
   folders?: ReportPathNode[];
   reports?: PathLeaf[];
 
   constructor(data: Record<string, unknown>) {
     this.id = data.id as number;
-    this.name = data.name as string | undefined;
-    this.permalink = data.permalink as string | undefined;
-    this.accessLevel = data.accessLevel as string | undefined;
+    this.name = data.name as string;
+    this.permalink = data.permalink as string;
+    this.accessLevel = data.accessLevel as APIAccessLevel | undefined;
     if (Array.isArray(data.folders)) {
       this.folders = (data.folders as Record<string, unknown>[]).map((f) => new ReportPathNode(f));
     }

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -1,4 +1,5 @@
 import type { PathLeaf } from '../types/PathLeaf';
+import type { PathNode } from '../types/PathNode';
 import type { RequestCallback } from '../types/RequestCallback';
 import type { RequestOptions } from '../types/RequestOptions';
 import type { BaseResponseStatus } from '../types/BaseResponseStatus';
@@ -11,7 +12,6 @@ import type { CrossSheetReference } from '../cross-sheet-references/types';
 import type { SheetSummary } from '../sheet-summary/types';
 import type { SheetUserSettings } from '../sheets/types';
 import type { WorkspaceListing } from '../workspaces/types';
-import type { APIAccessLevel } from '../types/ApiAccessLevel';
 
 // ============================================================================
 // Reports API Interface
@@ -1665,56 +1665,43 @@ export interface CreateReportResponse extends BaseResponseStatus {
 // Get Report Path
 // ============================================================================
 
-export class ReportPathNode {
-  id: number;
-  name: string;
-  permalink: string;
-  accessLevel?: APIAccessLevel;
+export interface ReportPathNode extends PathNode {
   folders?: ReportPathNode[];
   reports?: PathLeaf[];
+}
 
-  constructor(data: Record<string, unknown>) {
-    this.id = data.id as number;
-    this.name = data.name as string;
-    this.permalink = data.permalink as string;
-    this.accessLevel = data.accessLevel as APIAccessLevel | undefined;
-    if (Array.isArray(data.folders)) {
-      this.folders = (data.folders as Record<string, unknown>[]).map((f) => new ReportPathNode(f));
-    }
-    if (Array.isArray(data.reports)) {
-      this.reports = data.reports as PathLeaf[];
-    }
+/**
+ * Returns the target {@link PathLeaf} report, or undefined if not reachable.
+ * Use this for quick access to the leaf report object from a path response.
+ */
+export function getLeafReport(node: ReportPathNode): PathLeaf | undefined {
+  if (node.reports && node.reports.length > 0) {
+    return node.reports[0];
   }
 
-  /** Returns the target PathLeaf report, or undefined if not reachable. */
-  getLeafReport(): PathLeaf | undefined {
-    if (this.reports && this.reports.length > 0) {
-      return this.reports[0];
-    }
-
-    if (this.folders && this.folders.length > 0) {
-      return this.folders[0].getLeafReport();
-    }
-
-    return undefined;
+  if (node.folders && node.folders.length > 0) {
+    return getLeafReport(node.folders[0]);
   }
 
-  /**
-   * Returns a Unix-like slash-separated path string from this node to the target report.
-   *
-   * @example '/Workspace/Folder/Report'
-   **/
-  getLeafReportPath(): string | undefined {
-    if (this.reports && this.reports.length > 0) {
-      return `/${this.reports[0].name}`;
-    }
+  return undefined;
+}
 
-    if (this.folders && this.folders.length > 0) {
-      return `/${this.name}${this.folders[0].getLeafReportPath()}`;
-    }
-
-    return undefined;
+/**
+ * Returns a Unix-like slash-separated path string from the given node to the target report.
+ * Use this for quick access to the full path string of the leaf report from a path response.
+ *
+ * @example '/Workspace/Folder/Report'
+ */
+export function getLeafReportPath(node: ReportPathNode): string | undefined {
+  if (node.reports && node.reports.length > 0) {
+    return `/${node.reports[0].name}`;
   }
+
+  if (node.folders && node.folders.length > 0) {
+    return `/${node.name}${getLeafReportPath(node.folders[0])}`;
+  }
+
+  return undefined;
 }
 
 export interface GetReportPathOptions extends RequestOptions<undefined, undefined> {

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -11,7 +11,7 @@ import type { CrossSheetReference } from '../cross-sheet-references/types';
 import type { SheetSummary } from '../sheet-summary/types';
 import type { SheetUserSettings } from '../sheets/types';
 import type { WorkspaceListing } from '../workspaces/types';
-import { APIAccessLevel } from '@smartsheet/types';
+import type { APIAccessLevel } from '@smartsheet/types';
 
 // ============================================================================
 // Reports API Interface

--- a/lib/sheets/helpers.ts
+++ b/lib/sheets/helpers.ts
@@ -1,0 +1,54 @@
+import type { PathLeaf } from '../types/PathLeaf';
+import type { SheetPathNode } from './types';
+
+/**
+ * Returns the target {@link PathLeaf} sheet, or undefined if not reachable.
+ * Use this for quick access to the leaf sheet object from a path response.
+ *
+ * @param node - The root {@link SheetPathNode} returned by `getSheetPath`
+ * @returns The leaf {@link PathLeaf} sheet, or `undefined` if not found
+ *
+ * @example
+ * ```typescript
+ * const path = await client.sheets.getSheetPath({ sheetId: 123456789 });
+ * const leaf = getLeafSheet(path);
+ * console.log(leaf?.name);
+ * ```
+ */
+export function getLeafSheet(node: SheetPathNode): PathLeaf | undefined {
+  if (node.sheets && node.sheets.length > 0) {
+    return node.sheets[0];
+  }
+
+  if (node.folders && node.folders.length > 0) {
+    return getLeafSheet(node.folders[0]);
+  }
+
+  return undefined;
+}
+
+/**
+ * Returns a Unix-like slash-separated path string from the given node to the target sheet.
+ * Use this for quick access to the full path string of the leaf sheet from a path response.
+ *
+ * @param node - The root {@link SheetPathNode} returned by `getSheetPath`
+ * @returns A slash-separated path string, or `undefined` if not reachable
+ *
+ * @example
+ * ```typescript
+ * const path = await client.sheets.getSheetPath({ sheetId: 123456789 });
+ * const pathStr = getLeafSheetPath(path);
+ * console.log(pathStr); // '/Workspace/Folder/Sheet'
+ * ```
+ */
+export function getLeafSheetPath(node: SheetPathNode): string | undefined {
+  if (node.sheets && node.sheets.length > 0) {
+    return `/${node.sheets[0].name}`;
+  }
+
+  if (node.folders && node.folders.length > 0) {
+    return `/${node.name}${getLeafSheetPath(node.folders[0])}`;
+  }
+
+  return undefined;
+}

--- a/lib/sheets/index.js
+++ b/lib/sheets/index.js
@@ -1,5 +1,4 @@
 import _ from 'underscore';
-import { SheetPathNode } from './types';
 import * as attachments from './attachments';
 import * as automationRules from './automationrules';
 import * as columns from './columns';
@@ -61,9 +60,8 @@ export function create(options) {
     return requestor
       .get(_.extend({}, optionsToSend, urlOptions, getOptions))
       .then((data) => {
-        const node = new SheetPathNode(data);
-        if (callback) callback(undefined, node);
-        return node;
+        if (callback) callback(undefined, data);
+        return data;
       })
       .catch((err) => {
         if (callback) callback(err, undefined);

--- a/lib/sheets/index.js
+++ b/lib/sheets/index.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import { SheetPathNode } from './types';
 import * as attachments from './attachments';
 import * as automationRules from './automationrules';
 import * as columns from './columns';
@@ -55,6 +56,21 @@ export function create(options) {
     return requestor.post(_.extend({}, optionsToSend, urlOptions, postOptions), callback);
   };
 
+  const getSheetPath = (getOptions, callback) => {
+    const urlOptions = { url: options.apiUrls.sheets + '/' + getOptions.sheetId + '/path' };
+    return requestor
+      .get(_.extend({}, optionsToSend, urlOptions, getOptions))
+      .then((data) => {
+        const node = new SheetPathNode(data);
+        if (callback) callback(undefined, node);
+        return node;
+      })
+      .catch((err) => {
+        if (callback) callback(err, undefined);
+        return Promise.reject(err);
+      });
+  };
+
   const sheetObject = {
     sendSheetViaEmail: sendSheetViaEmail,
     getPublishStatus: getPublishStatus,
@@ -63,6 +79,7 @@ export function create(options) {
     deleteSheet: deleteSheet,
     moveSheet: moveSheet,
     sortRowsInSheet: sortRowsInSheet,
+    getSheetPath: getSheetPath,
   };
 
   _.extend(sheetObject, attachments.create(options));

--- a/lib/sheets/index.js
+++ b/lib/sheets/index.js
@@ -57,16 +57,7 @@ export function create(options) {
 
   const getSheetPath = (getOptions, callback) => {
     const urlOptions = { url: options.apiUrls.sheets + '/' + getOptions.sheetId + '/path' };
-    return requestor
-      .get(_.extend({}, optionsToSend, urlOptions, getOptions))
-      .then((data) => {
-        if (callback) callback(undefined, data);
-        return data;
-      })
-      .catch((err) => {
-        if (callback) callback(err, undefined);
-        return Promise.reject(err);
-      });
+    return requestor.get(_.extend({}, optionsToSend, urlOptions, getOptions), callback);
   };
 
   const sheetObject = {

--- a/lib/sheets/types.ts
+++ b/lib/sheets/types.ts
@@ -1,3 +1,66 @@
+// ============================================================================
+// Get Sheet Path
+// ============================================================================
+
+export interface SheetPathLeaf {
+  id: number;
+  name?: string;
+  permalink?: string;
+  accessLevel?: string;
+  createdAt?: string;
+  modifiedAt?: string;
+}
+
+export class SheetPathNode {
+  id: number;
+  name?: string;
+  permalink?: string;
+  accessLevel?: string;
+  folders?: SheetPathNode[];
+  sheets?: SheetPathLeaf[];
+
+  constructor(data: Record<string, unknown>) {
+    this.id = data.id as number;
+    this.name = data.name as string | undefined;
+    this.permalink = data.permalink as string | undefined;
+    this.accessLevel = data.accessLevel as string | undefined;
+    if (Array.isArray(data.folders)) {
+      this.folders = (data.folders as Record<string, unknown>[]).map((f) => new SheetPathNode(f));
+    }
+    if (Array.isArray(data.sheets)) {
+      this.sheets = data.sheets as SheetPathLeaf[];
+    }
+  }
+
+  private _walkToLeaf(): SheetPathNode[] {
+    if (this.sheets && this.sheets.length > 0) return [this];
+    if (this.folders && this.folders.length > 0) {
+      return [this, ...this.folders[0]._walkToLeaf()];
+    }
+    return [this];
+  }
+
+  /** Returns the target SheetPathLeaf sheet, or undefined if not reachable. */
+  getSheet(): SheetPathLeaf | undefined {
+    for (const node of this._walkToLeaf()) {
+      if (node.sheets && node.sheets.length > 0) return node.sheets[0];
+    }
+    return undefined;
+  }
+
+  /** Returns a slash-separated path string from this node to the target sheet. */
+  getSheetPath(): string | undefined {
+    const nodes = this._walkToLeaf();
+    if (nodes.length === 0) return undefined;
+    const parts = nodes.map((n) => n.name).filter(Boolean) as string[];
+    const leaf = nodes[nodes.length - 1];
+    if (leaf.sheets && leaf.sheets.length > 0 && leaf.sheets[0].name) {
+      parts[parts.length - 1] = leaf.sheets[0].name;
+    }
+    return parts.length > 0 ? parts.join('/') : undefined;
+  }
+}
+
 export interface SheetUserSettings {
   /**
    * Does this user have "Show Critical Path" turned on for this sheet? NOTE: This setting only has an effect on project sheets with dependencies enabled.

--- a/lib/sheets/types.ts
+++ b/lib/sheets/types.ts
@@ -9,7 +9,7 @@ export class SheetPathNode {
   id: number;
   name: string;
   permalink: string;
-  accessLevel?: string;
+  accessLevel?: APIAccessLevel;
   folders?: SheetPathNode[];
   sheets?: PathLeaf[];
 
@@ -26,32 +26,34 @@ export class SheetPathNode {
     }
   }
 
-  private _walkToLeaf(): SheetPathNode[] {
-    if (this.sheets && this.sheets.length > 0) return [this];
-    if (this.folders && this.folders.length > 0) {
-      return [this, ...this.folders[0]._walkToLeaf()];
-    }
-    return [this];
-  }
-
   /** Returns the target PathLeaf sheet, or undefined if not reachable. */
-  getSheet(): PathLeaf | undefined {
-    for (const node of this._walkToLeaf()) {
-      if (node.sheets && node.sheets.length > 0) return node.sheets[0];
+  getLeafSheet(): PathLeaf | undefined {
+    if (this.sheets && this.sheets.length > 0) {
+      return this.sheets[0];
     }
+
+    if (this.folders && this.folders.length > 0) {
+      return this.folders[0].getLeafSheet();
+    }
+
     return undefined;
   }
 
-  /** Returns a slash-separated path string from this node to the target sheet. */
-  getSheetPath(): string | undefined {
-    const nodes = this._walkToLeaf();
-    if (nodes.length === 0) return undefined;
-    const parts = nodes.map((n) => n.name).filter(Boolean) as string[];
-    const leaf = nodes[nodes.length - 1];
-    if (leaf.sheets && leaf.sheets.length > 0 && leaf.sheets[0].name) {
-      parts[parts.length - 1] = leaf.sheets[0].name;
+  /**
+   * Returns a Unix-like slash-separated path string from this node to the target sheet.
+   *
+   * @example '/Workspace/Folder/Sheet'
+   **/
+  getLeafSheetPath(): string | undefined {
+    if (this.sheets && this.sheets.length > 0) {
+      return `/${this.sheets[0].name}`;
     }
-    return parts.length > 0 ? parts.join('/') : undefined;
+
+    if (this.folders && this.folders.length > 0) {
+      return `/${this.name}${this.folders[0].getLeafSheetPath()}`;
+    }
+
+    return undefined;
   }
 }
 

--- a/lib/sheets/types.ts
+++ b/lib/sheets/types.ts
@@ -3,58 +3,45 @@
 // ============================================================================
 
 import type { PathLeaf } from '../types/PathLeaf';
-import type { APIAccessLevel } from '../types/ApiAccessLevel';
+import type { PathNode } from '../types/PathNode';
 
-export class SheetPathNode {
-  id: number;
-  name: string;
-  permalink: string;
-  accessLevel?: APIAccessLevel;
+export interface SheetPathNode extends PathNode {
   folders?: SheetPathNode[];
   sheets?: PathLeaf[];
+}
 
-  constructor(data: Record<string, unknown>) {
-    this.id = data.id as number;
-    this.name = data.name as string;
-    this.permalink = data.permalink as string;
-    this.accessLevel = data.accessLevel as APIAccessLevel | undefined;
-    if (Array.isArray(data.folders)) {
-      this.folders = (data.folders as Record<string, unknown>[]).map((f) => new SheetPathNode(f));
-    }
-    if (Array.isArray(data.sheets)) {
-      this.sheets = data.sheets as PathLeaf[];
-    }
+/**
+ * Returns the target {@link PathLeaf} sheet, or undefined if not reachable.
+ * Use this for quick access to the leaf sheet object from a path response.
+ */
+export function getLeafSheet(node: SheetPathNode): PathLeaf | undefined {
+  if (node.sheets && node.sheets.length > 0) {
+    return node.sheets[0];
   }
 
-  /** Returns the target PathLeaf sheet, or undefined if not reachable. */
-  getLeafSheet(): PathLeaf | undefined {
-    if (this.sheets && this.sheets.length > 0) {
-      return this.sheets[0];
-    }
-
-    if (this.folders && this.folders.length > 0) {
-      return this.folders[0].getLeafSheet();
-    }
-
-    return undefined;
+  if (node.folders && node.folders.length > 0) {
+    return getLeafSheet(node.folders[0]);
   }
 
-  /**
-   * Returns a Unix-like slash-separated path string from this node to the target sheet.
-   *
-   * @example '/Workspace/Folder/Sheet'
-   **/
-  getLeafSheetPath(): string | undefined {
-    if (this.sheets && this.sheets.length > 0) {
-      return `/${this.sheets[0].name}`;
-    }
+  return undefined;
+}
 
-    if (this.folders && this.folders.length > 0) {
-      return `/${this.name}${this.folders[0].getLeafSheetPath()}`;
-    }
-
-    return undefined;
+/**
+ * Returns a Unix-like slash-separated path string from the given node to the target sheet.
+ * Use this for quick access to the full path string of the leaf sheet from a path response.
+ *
+ * @example '/Workspace/Folder/Sheet'
+ */
+export function getLeafSheetPath(node: SheetPathNode): string | undefined {
+  if (node.sheets && node.sheets.length > 0) {
+    return `/${node.sheets[0].name}`;
   }
+
+  if (node.folders && node.folders.length > 0) {
+    return `/${node.name}${getLeafSheetPath(node.folders[0])}`;
+  }
+
+  return undefined;
 }
 
 export interface SheetUserSettings {

--- a/lib/sheets/types.ts
+++ b/lib/sheets/types.ts
@@ -5,43 +5,17 @@
 import type { PathLeaf } from '../types/PathLeaf';
 import type { PathNode } from '../types/PathNode';
 
+/**
+ * Represents a node in the path tree from the workspace root to the target sheet.
+ * Returned by `getSheetPath`. Use {@link getLeafSheet} to extract the leaf sheet object,
+ * or {@link getLeafSheetPath} to get the full slash-separated path string.
+ *
+ * @see getLeafSheet
+ * @see getLeafSheetPath
+ */
 export interface SheetPathNode extends PathNode {
   folders?: SheetPathNode[];
   sheets?: PathLeaf[];
-}
-
-/**
- * Returns the target {@link PathLeaf} sheet, or undefined if not reachable.
- * Use this for quick access to the leaf sheet object from a path response.
- */
-export function getLeafSheet(node: SheetPathNode): PathLeaf | undefined {
-  if (node.sheets && node.sheets.length > 0) {
-    return node.sheets[0];
-  }
-
-  if (node.folders && node.folders.length > 0) {
-    return getLeafSheet(node.folders[0]);
-  }
-
-  return undefined;
-}
-
-/**
- * Returns a Unix-like slash-separated path string from the given node to the target sheet.
- * Use this for quick access to the full path string of the leaf sheet from a path response.
- *
- * @example '/Workspace/Folder/Sheet'
- */
-export function getLeafSheetPath(node: SheetPathNode): string | undefined {
-  if (node.sheets && node.sheets.length > 0) {
-    return `/${node.sheets[0].name}`;
-  }
-
-  if (node.folders && node.folders.length > 0) {
-    return `/${node.name}${getLeafSheetPath(node.folders[0])}`;
-  }
-
-  return undefined;
 }
 
 export interface SheetUserSettings {

--- a/lib/sheets/types.ts
+++ b/lib/sheets/types.ts
@@ -2,33 +2,27 @@
 // Get Sheet Path
 // ============================================================================
 
-export interface SheetPathLeaf {
-  id: number;
-  name?: string;
-  permalink?: string;
-  accessLevel?: string;
-  createdAt?: string;
-  modifiedAt?: string;
-}
+import type { PathLeaf } from '../types/PathLeaf';
+import type { APIAccessLevel } from '@smartsheet/types';
 
 export class SheetPathNode {
   id: number;
-  name?: string;
-  permalink?: string;
+  name: string;
+  permalink: string;
   accessLevel?: string;
   folders?: SheetPathNode[];
-  sheets?: SheetPathLeaf[];
+  sheets?: PathLeaf[];
 
   constructor(data: Record<string, unknown>) {
     this.id = data.id as number;
-    this.name = data.name as string | undefined;
-    this.permalink = data.permalink as string | undefined;
-    this.accessLevel = data.accessLevel as string | undefined;
+    this.name = data.name as string;
+    this.permalink = data.permalink as string;
+    this.accessLevel = data.accessLevel as APIAccessLevel | undefined;
     if (Array.isArray(data.folders)) {
       this.folders = (data.folders as Record<string, unknown>[]).map((f) => new SheetPathNode(f));
     }
     if (Array.isArray(data.sheets)) {
-      this.sheets = data.sheets as SheetPathLeaf[];
+      this.sheets = data.sheets as PathLeaf[];
     }
   }
 
@@ -40,8 +34,8 @@ export class SheetPathNode {
     return [this];
   }
 
-  /** Returns the target SheetPathLeaf sheet, or undefined if not reachable. */
-  getSheet(): SheetPathLeaf | undefined {
+  /** Returns the target PathLeaf sheet, or undefined if not reachable. */
+  getSheet(): PathLeaf | undefined {
     for (const node of this._walkToLeaf()) {
       if (node.sheets && node.sheets.length > 0) return node.sheets[0];
     }

--- a/lib/sheets/types.ts
+++ b/lib/sheets/types.ts
@@ -3,7 +3,7 @@
 // ============================================================================
 
 import type { PathLeaf } from '../types/PathLeaf';
-import type { APIAccessLevel } from '@smartsheet/types';
+import type { APIAccessLevel } from '../types/ApiAccessLevel';
 
 export class SheetPathNode {
   id: number;

--- a/lib/sights/helpers.ts
+++ b/lib/sights/helpers.ts
@@ -1,0 +1,54 @@
+import type { PathLeaf } from '../types/PathLeaf';
+import type { SightPathNode } from './types';
+
+/**
+ * Returns the target {@link PathLeaf} sight, or undefined if not reachable.
+ * Use this for quick access to the leaf sight object from a path response.
+ *
+ * @param node - The root {@link SightPathNode} returned by `getSightPath`
+ * @returns The leaf {@link PathLeaf} sight, or `undefined` if not found
+ *
+ * @example
+ * ```typescript
+ * const path = await client.sights.getSightPath({ sightId: 123456789 });
+ * const leaf = getLeafSight(path);
+ * console.log(leaf?.name);
+ * ```
+ */
+export function getLeafSight(node: SightPathNode): PathLeaf | undefined {
+  if (node.sights && node.sights.length > 0) {
+    return node.sights[0];
+  }
+
+  if (node.folders && node.folders.length > 0) {
+    return getLeafSight(node.folders[0]);
+  }
+
+  return undefined;
+}
+
+/**
+ * Returns a Unix-like slash-separated path string from the given node to the target sight.
+ * Use this for quick access to the full path string of the leaf sight from a path response.
+ *
+ * @param node - The root {@link SightPathNode} returned by `getSightPath`
+ * @returns A slash-separated path string, or `undefined` if not reachable
+ *
+ * @example
+ * ```typescript
+ * const path = await client.sights.getSightPath({ sightId: 123456789 });
+ * const pathStr = getLeafSightPath(path);
+ * console.log(pathStr); // '/Workspace/Folder/Dashboard'
+ * ```
+ */
+export function getLeafSightPath(node: SightPathNode): string | undefined {
+  if (node.sights && node.sights.length > 0) {
+    return `/${node.sights[0].name}`;
+  }
+
+  if (node.folders && node.folders.length > 0) {
+    return `/${node.name}${getLeafSightPath(node.folders[0])}`;
+  }
+
+  return undefined;
+}

--- a/lib/sights/index.ts
+++ b/lib/sights/index.ts
@@ -80,6 +80,13 @@ export function create(options: CreateOptions): SightsApi {
     return requestor.put({ ...optionsToSend, ...urlOptions, ...putOptions }, callback);
   };
 
+  const buildUrl = (sightId?: number | string) => {
+    if (sightId !== undefined) {
+      return options.apiUrls.sights + '/' + sightId;
+    }
+    return options.apiUrls.sights;
+  };
+
   const getSightPath = (
     getOptions: GetSightPathOptions,
     callback?: RequestCallback<SightPathNode>
@@ -96,13 +103,6 @@ export function create(options: CreateOptions): SightsApi {
         if (callback) callback(err as ApiError, undefined);
         return Promise.reject(err);
       });
-  };
-
-  const buildUrl = (sightId?: number | string) => {
-    if (sightId !== undefined) {
-      return options.apiUrls.sights + '/' + sightId;
-    }
-    return options.apiUrls.sights;
   };
 
   return {

--- a/lib/sights/index.ts
+++ b/lib/sights/index.ts
@@ -1,3 +1,4 @@
+import type { ApiError } from '../types/ApiError';
 import type { CreateOptions } from '../types/CreateOptions';
 import type { RequestCallback } from '../types/RequestCallback';
 import type { RequestOptions } from '../types/RequestOptions';
@@ -19,7 +20,9 @@ import type {
   SightPublishStatus,
   SetSightPublishStatusOptions,
   SetSightPublishStatusResponse,
+  GetSightPathOptions,
 } from './types';
+import { SightPathNode } from './types';
 
 export function create(options: CreateOptions): SightsApi {
   const requestor = options.requestor;
@@ -77,6 +80,24 @@ export function create(options: CreateOptions): SightsApi {
     return requestor.put({ ...optionsToSend, ...urlOptions, ...putOptions }, callback);
   };
 
+  const getSightPath = (
+    getOptions: GetSightPathOptions,
+    callback?: RequestCallback<SightPathNode>
+  ): Promise<SightPathNode> => {
+    const urlOptions = { url: buildUrl(getOptions.sightId) + '/path' };
+    return requestor
+      .get({ ...optionsToSend, ...urlOptions, ...getOptions })
+      .then((data: Record<string, unknown>) => {
+        const node = new SightPathNode(data);
+        if (callback) callback(undefined, node);
+        return node;
+      })
+      .catch((err: unknown) => {
+        if (callback) callback(err as ApiError, undefined);
+        return Promise.reject(err);
+      });
+  };
+
   const buildUrl = (sightId?: number | string) => {
     if (sightId !== undefined) {
       return options.apiUrls.sights + '/' + sightId;
@@ -93,6 +114,7 @@ export function create(options: CreateOptions): SightsApi {
     moveSight,
     getSightPublishStatus,
     setSightPublishStatus,
+    getSightPath,
   };
 }
 

--- a/lib/sights/index.ts
+++ b/lib/sights/index.ts
@@ -22,7 +22,7 @@ import type {
   SetSightPublishStatusResponse,
   GetSightPathOptions,
 } from './types';
-import { SightPathNode } from './types';
+import type { SightPathNode } from './types';
 
 export function create(options: CreateOptions): SightsApi {
   const requestor = options.requestor;
@@ -94,10 +94,9 @@ export function create(options: CreateOptions): SightsApi {
     const urlOptions = { url: buildUrl(getOptions.sightId) + '/path' };
     return requestor
       .get({ ...optionsToSend, ...urlOptions, ...getOptions })
-      .then((data: Record<string, unknown>) => {
-        const node = new SightPathNode(data);
-        if (callback) callback(undefined, node);
-        return node;
+      .then((data: SightPathNode) => {
+        if (callback) callback(undefined, data);
+        return data;
       })
       .catch((err: unknown) => {
         if (callback) callback(err as ApiError, undefined);

--- a/lib/sights/index.ts
+++ b/lib/sights/index.ts
@@ -1,4 +1,3 @@
-import type { ApiError } from '../types/ApiError';
 import type { CreateOptions } from '../types/CreateOptions';
 import type { RequestCallback } from '../types/RequestCallback';
 import type { RequestOptions } from '../types/RequestOptions';
@@ -92,16 +91,7 @@ export function create(options: CreateOptions): SightsApi {
     callback?: RequestCallback<SightPathNode>
   ): Promise<SightPathNode> => {
     const urlOptions = { url: buildUrl(getOptions.sightId) + '/path' };
-    return requestor
-      .get({ ...optionsToSend, ...urlOptions, ...getOptions })
-      .then((data: SightPathNode) => {
-        if (callback) callback(undefined, data);
-        return data;
-      })
-      .catch((err: unknown) => {
-        if (callback) callback(err as ApiError, undefined);
-        return Promise.reject(err);
-      });
+    return requestor.get({ ...optionsToSend, ...urlOptions, ...getOptions }, callback);
   };
 
   return {

--- a/lib/sights/types.ts
+++ b/lib/sights/types.ts
@@ -3,6 +3,7 @@ import type { RequestOptions } from '../types/RequestOptions';
 import type { BaseResponseStatus } from '../types/BaseResponseStatus';
 import type { APIAccessLevel } from '../types/ApiAccessLevel';
 import type { PathLeaf } from '../types/PathLeaf';
+import type { PathNode } from '../types/PathNode';
 import type { TokenPaginationQueryParameters, TokenPaginationResponse } from '../types';
 
 // ============================================================================
@@ -610,56 +611,43 @@ export interface SetSightPublishStatusResponse extends BaseResponseStatus {
 // Get Sight Path
 // ============================================================================
 
-export class SightPathNode {
-  id: number;
-  name: string;
-  permalink: string;
-  accessLevel?: APIAccessLevel;
+export interface SightPathNode extends PathNode {
   folders?: SightPathNode[];
   sights?: PathLeaf[];
+}
 
-  constructor(data: Record<string, unknown>) {
-    this.id = data.id as number;
-    this.name = data.name as string;
-    this.permalink = data.permalink as string;
-    this.accessLevel = data.accessLevel as APIAccessLevel | undefined;
-    if (Array.isArray(data.folders)) {
-      this.folders = (data.folders as Record<string, unknown>[]).map((f) => new SightPathNode(f));
-    }
-    if (Array.isArray(data.sights)) {
-      this.sights = data.sights as PathLeaf[];
-    }
+/**
+ * Returns the target {@link PathLeaf} sight, or undefined if not reachable.
+ * Use this for quick access to the leaf sight object from a path response.
+ */
+export function getLeafSight(node: SightPathNode): PathLeaf | undefined {
+  if (node.sights && node.sights.length > 0) {
+    return node.sights[0];
   }
 
-  /** Returns the target PathLeaf sight, or undefined if not reachable. */
-  getLeafSight(): PathLeaf | undefined {
-    if (this.sights && this.sights.length > 0) {
-      return this.sights[0];
-    }
-
-    if (this.folders && this.folders.length > 0) {
-      return this.folders[0].getLeafSight();
-    }
-
-    return undefined;
+  if (node.folders && node.folders.length > 0) {
+    return getLeafSight(node.folders[0]);
   }
 
-  /**
-   * Returns a Unix-like slash-separated path string from this node to the target sight.
-   *
-   * @example '/Workspace/Folder/Dashboard'
-   **/
-  getLeafSightPath(): string | undefined {
-    if (this.sights && this.sights.length > 0) {
-      return `/${this.sights[0].name}`;
-    }
+  return undefined;
+}
 
-    if (this.folders && this.folders.length > 0) {
-      return `/${this.name}${this.folders[0].getLeafSightPath()}`;
-    }
-
-    return undefined;
+/**
+ * Returns a Unix-like slash-separated path string from the given node to the target sight.
+ * Use this for quick access to the full path string of the leaf sight from a path response.
+ *
+ * @example '/Workspace/Folder/Dashboard'
+ */
+export function getLeafSightPath(node: SightPathNode): string | undefined {
+  if (node.sights && node.sights.length > 0) {
+    return `/${node.sights[0].name}`;
   }
+
+  if (node.folders && node.folders.length > 0) {
+    return `/${node.name}${getLeafSightPath(node.folders[0])}`;
+  }
+
+  return undefined;
 }
 
 export interface GetSightPathOptions extends RequestOptions<undefined, undefined> {

--- a/lib/sights/types.ts
+++ b/lib/sights/types.ts
@@ -2,6 +2,7 @@ import type { RequestCallback } from '../types/RequestCallback';
 import type { RequestOptions } from '../types/RequestOptions';
 import type { BaseResponseStatus } from '../types/BaseResponseStatus';
 import type { APIAccessLevel } from '../types/ApiAccessLevel';
+import type { PathLeaf } from '../types/PathLeaf';
 import type { TokenPaginationQueryParameters, TokenPaginationResponse } from '../types';
 
 // ============================================================================
@@ -609,33 +610,24 @@ export interface SetSightPublishStatusResponse extends BaseResponseStatus {
 // Get Sight Path
 // ============================================================================
 
-export interface SightPathLeaf {
-  id: number;
-  name?: string;
-  permalink?: string;
-  accessLevel?: string;
-  createdAt?: string;
-  modifiedAt?: string;
-}
-
 export class SightPathNode {
   id: number;
-  name?: string;
-  permalink?: string;
-  accessLevel?: string;
+  name: string;
+  permalink: string;
+  accessLevel?: APIAccessLevel;
   folders?: SightPathNode[];
-  sights?: SightPathLeaf[];
+  sights?: PathLeaf[];
 
   constructor(data: Record<string, unknown>) {
     this.id = data.id as number;
-    this.name = data.name as string | undefined;
-    this.permalink = data.permalink as string | undefined;
-    this.accessLevel = data.accessLevel as string | undefined;
+    this.name = data.name as string;
+    this.permalink = data.permalink as string;
+    this.accessLevel = data.accessLevel as APIAccessLevel | undefined;
     if (Array.isArray(data.folders)) {
       this.folders = (data.folders as Record<string, unknown>[]).map((f) => new SightPathNode(f));
     }
     if (Array.isArray(data.sights)) {
-      this.sights = data.sights as SightPathLeaf[];
+      this.sights = data.sights as PathLeaf[];
     }
   }
 
@@ -647,8 +639,8 @@ export class SightPathNode {
     return [this];
   }
 
-  /** Returns the target SightPathLeaf sight, or undefined if not reachable. */
-  getSight(): SightPathLeaf | undefined {
+  /** Returns the target PathLeaf sight, or undefined if not reachable. */
+  getSight(): PathLeaf | undefined {
     for (const node of this.walkToLeaf()) {
       if (node.sights && node.sights.length > 0) return node.sights[0];
     }

--- a/lib/sights/types.ts
+++ b/lib/sights/types.ts
@@ -631,32 +631,34 @@ export class SightPathNode {
     }
   }
 
-  private walkToLeaf(): SightPathNode[] {
-    if (this.sights && this.sights.length > 0) return [this];
-    if (this.folders && this.folders.length > 0) {
-      return [this, ...this.folders[0].walkToLeaf()];
-    }
-    return [this];
-  }
-
   /** Returns the target PathLeaf sight, or undefined if not reachable. */
-  getSight(): PathLeaf | undefined {
-    for (const node of this.walkToLeaf()) {
-      if (node.sights && node.sights.length > 0) return node.sights[0];
+  getLeafSight(): PathLeaf | undefined {
+    if (this.sights && this.sights.length > 0) {
+      return this.sights[0];
     }
+
+    if (this.folders && this.folders.length > 0) {
+      return this.folders[0].getLeafSight();
+    }
+
     return undefined;
   }
 
-  /** Returns a slash-separated path string from this node to the target sight. */
-  getSightPath(): string | undefined {
-    const nodes = this.walkToLeaf();
-    if (nodes.length === 0) return undefined;
-    const parts = nodes.map((n) => n.name).filter(Boolean) as string[];
-    const leaf = nodes[nodes.length - 1];
-    if (leaf.sights && leaf.sights.length > 0 && leaf.sights[0].name) {
-      parts[parts.length - 1] = leaf.sights[0].name;
+  /**
+   * Returns a Unix-like slash-separated path string from this node to the target sight.
+   *
+   * @example '/Workspace/Folder/Dashboard'
+   **/
+  getLeafSightPath(): string | undefined {
+    if (this.sights && this.sights.length > 0) {
+      return `/${this.sights[0].name}`;
     }
-    return parts.length > 0 ? parts.join('/') : undefined;
+
+    if (this.folders && this.folders.length > 0) {
+      return `/${this.name}${this.folders[0].getLeafSightPath()}`;
+    }
+
+    return undefined;
   }
 }
 

--- a/lib/sights/types.ts
+++ b/lib/sights/types.ts
@@ -193,6 +193,28 @@ export interface SightsApi {
     options: SetSightPublishStatusOptions,
     callback?: RequestCallback<SetSightPublishStatusResponse>
   ) => Promise<SetSightPublishStatusResponse>;
+
+  /**
+   * Gets the path from the workspace root to the specified sight (dashboard).
+   *
+   * @param options - {@link GetSightPathOptions} - Configuration options for the request
+   * @param callback - {@link RequestCallback}\<{@link SightPathNode}\> - Optional callback function
+   * @returns Promise\<{@link SightPathNode}\>
+   *
+   * @remarks
+   * It mirrors to the following Smartsheet REST API method: `GET /sights/{sightId}/path`
+   *
+   * @example
+   * ```typescript
+   * const path = await client.sights.getSightPath({
+   *   sightId: 123456789
+   * });
+   * ```
+   */
+  getSightPath: (
+    options: GetSightPathOptions,
+    callback?: RequestCallback<SightPathNode>
+  ) => Promise<SightPathNode>;
 }
 
 // ============================================================================
@@ -584,4 +606,74 @@ export interface SetSightPublishStatusResponse extends BaseResponseStatus {
    * @see SightPublishStatus
    */
   result: SightPublishStatus;
+}
+
+// ============================================================================
+// Get Sight Path
+// ============================================================================
+
+export interface SightPathLeaf {
+  id: number;
+  name?: string;
+  permalink?: string;
+  accessLevel?: string;
+  createdAt?: string;
+  modifiedAt?: string;
+}
+
+export class SightPathNode {
+  id: number;
+  name?: string;
+  permalink?: string;
+  accessLevel?: string;
+  folders?: SightPathNode[];
+  sights?: SightPathLeaf[];
+
+  constructor(data: Record<string, unknown>) {
+    this.id = data.id as number;
+    this.name = data.name as string | undefined;
+    this.permalink = data.permalink as string | undefined;
+    this.accessLevel = data.accessLevel as string | undefined;
+    if (Array.isArray(data.folders)) {
+      this.folders = (data.folders as Record<string, unknown>[]).map((f) => new SightPathNode(f));
+    }
+    if (Array.isArray(data.sights)) {
+      this.sights = data.sights as SightPathLeaf[];
+    }
+  }
+
+  private walkToLeaf(): SightPathNode[] {
+    if (this.sights && this.sights.length > 0) return [this];
+    if (this.folders && this.folders.length > 0) {
+      return [this, ...this.folders[0].walkToLeaf()];
+    }
+    return [this];
+  }
+
+  /** Returns the target SightPathLeaf sight, or undefined if not reachable. */
+  getSight(): SightPathLeaf | undefined {
+    for (const node of this.walkToLeaf()) {
+      if (node.sights && node.sights.length > 0) return node.sights[0];
+    }
+    return undefined;
+  }
+
+  /** Returns a slash-separated path string from this node to the target sight. */
+  getSightPath(): string | undefined {
+    const nodes = this.walkToLeaf();
+    if (nodes.length === 0) return undefined;
+    const parts = nodes.map((n) => n.name).filter(Boolean) as string[];
+    const leaf = nodes[nodes.length - 1];
+    if (leaf.sights && leaf.sights.length > 0 && leaf.sights[0].name) {
+      parts[parts.length - 1] = leaf.sights[0].name;
+    }
+    return parts.length > 0 ? parts.join('/') : undefined;
+  }
+}
+
+export interface GetSightPathOptions extends RequestOptions<undefined, undefined> {
+  /**
+   * Sight Id.
+   */
+  sightId: number;
 }

--- a/lib/sights/types.ts
+++ b/lib/sights/types.ts
@@ -611,45 +611,25 @@ export interface SetSightPublishStatusResponse extends BaseResponseStatus {
 // Get Sight Path
 // ============================================================================
 
+/**
+ * Represents a node in the path tree from the workspace root to the target sight (dashboard).
+ * Returned by `getSightPath`. Use {@link getLeafSight} to extract the leaf sight object,
+ * or {@link getLeafSightPath} to get the full slash-separated path string.
+ *
+ * @see getLeafSight
+ * @see getLeafSightPath
+ */
 export interface SightPathNode extends PathNode {
   folders?: SightPathNode[];
   sights?: PathLeaf[];
 }
 
 /**
- * Returns the target {@link PathLeaf} sight, or undefined if not reachable.
- * Use this for quick access to the leaf sight object from a path response.
- */
-export function getLeafSight(node: SightPathNode): PathLeaf | undefined {
-  if (node.sights && node.sights.length > 0) {
-    return node.sights[0];
-  }
-
-  if (node.folders && node.folders.length > 0) {
-    return getLeafSight(node.folders[0]);
-  }
-
-  return undefined;
-}
-
-/**
- * Returns a Unix-like slash-separated path string from the given node to the target sight.
- * Use this for quick access to the full path string of the leaf sight from a path response.
+ * Options for getting the path from the workspace root to the specified sight (dashboard).
  *
- * @example '/Workspace/Folder/Dashboard'
+ * @remarks
+ * It mirrors to the following Smartsheet REST API method: `GET /sights/{sightId}/path`
  */
-export function getLeafSightPath(node: SightPathNode): string | undefined {
-  if (node.sights && node.sights.length > 0) {
-    return `/${node.sights[0].name}`;
-  }
-
-  if (node.folders && node.folders.length > 0) {
-    return `/${node.name}${getLeafSightPath(node.folders[0])}`;
-  }
-
-  return undefined;
-}
-
 export interface GetSightPathOptions extends RequestOptions<undefined, undefined> {
   /**
    * Sight Id.

--- a/lib/sights/types.ts
+++ b/lib/sights/types.ts
@@ -211,10 +211,7 @@ export interface SightsApi {
    * });
    * ```
    */
-  getSightPath: (
-    options: GetSightPathOptions,
-    callback?: RequestCallback<SightPathNode>
-  ) => Promise<SightPathNode>;
+  getSightPath: (options: GetSightPathOptions, callback?: RequestCallback<SightPathNode>) => Promise<SightPathNode>;
 }
 
 // ============================================================================

--- a/lib/types/PathLeaf.ts
+++ b/lib/types/PathLeaf.ts
@@ -1,8 +1,10 @@
+import type { APIAccessLevel } from '@smartsheet/types';
+
 export interface PathLeaf {
   id: number;
   name: string;
   permalink: string;
-  accessLevel: string;
+  accessLevel: APIAccessLevel;
   createdAt: string;
   modifiedAt: string;
 }

--- a/lib/types/PathLeaf.ts
+++ b/lib/types/PathLeaf.ts
@@ -1,4 +1,4 @@
-import type { APIAccessLevel } from '@smartsheet/types';
+import type { APIAccessLevel } from './ApiAccessLevel';
 
 export interface PathLeaf {
   id: number;

--- a/lib/types/PathLeaf.ts
+++ b/lib/types/PathLeaf.ts
@@ -1,10 +1,7 @@
-import type { APIAccessLevel } from './ApiAccessLevel';
+import type { PathNode } from './PathNode';
 
-export interface PathLeaf {
-  id: number;
-  name: string;
-  permalink: string;
-  accessLevel: APIAccessLevel;
+export interface PathLeaf extends PathNode {
+  accessLevel: NonNullable<PathNode['accessLevel']>;
   createdAt: string;
   modifiedAt: string;
 }

--- a/lib/types/PathLeaf.ts
+++ b/lib/types/PathLeaf.ts
@@ -1,0 +1,8 @@
+export interface PathLeaf {
+  id: number;
+  name: string;
+  permalink: string;
+  accessLevel: string;
+  createdAt: string;
+  modifiedAt: string;
+}

--- a/lib/types/PathNode.ts
+++ b/lib/types/PathNode.ts
@@ -1,0 +1,8 @@
+import type { APIAccessLevel } from './ApiAccessLevel';
+
+export interface PathNode {
+  id: number;
+  name: string;
+  permalink: string;
+  accessLevel?: APIAccessLevel;
+}

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -7,6 +7,7 @@ export * from './CreateClientOptions';
 export * from './CreateOptions';
 export * from './FailedItem';
 export * from './ObjectValue';
+export * from './PathLeaf';
 export * from './RequestCallback';
 export * from './RequestOptions';
 export * from './SmartsheetClient';

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -8,6 +8,7 @@ export * from './CreateOptions';
 export * from './FailedItem';
 export * from './ObjectValue';
 export * from './PathLeaf';
+export * from './PathNode';
 export * from './RequestCallback';
 export * from './RequestOptions';
 export * from './SmartsheetClient';

--- a/test/functional/client.spec.ts
+++ b/test/functional/client.spec.ts
@@ -87,12 +87,13 @@ describe('Client Unit Tests', () => {
   describe('#folders', () => {
     it('should have folders object', () => {
       expect(smartsheet).toHaveProperty('folders');
-      expect(Object.keys(smartsheet.folders)).toHaveLength(7);
+      expect(Object.keys(smartsheet.folders)).toHaveLength(8);
     });
 
     it('should have get methods', () => {
       expect(smartsheet.folders).toHaveProperty('getFolderMetadata');
       expect(smartsheet.folders).toHaveProperty('getFolderChildren');
+      expect(smartsheet.folders).toHaveProperty('getFolderPath');
     });
 
     it('should have create methods', () => {
@@ -178,7 +179,7 @@ describe('Client Unit Tests', () => {
   describe('#reports', () => {
     it('should have reports object', () => {
       expect(smartsheet).toHaveProperty('reports');
-      expect(Object.keys(smartsheet.reports)).toHaveLength(13);
+      expect(Object.keys(smartsheet.reports)).toHaveLength(14);
     });
 
     it('should have get methods', () => {
@@ -187,6 +188,7 @@ describe('Client Unit Tests', () => {
       expect(smartsheet.reports).toHaveProperty('getReportAsExcel');
       expect(smartsheet.reports).toHaveProperty('getReportAsCSV');
       expect(smartsheet.reports).toHaveProperty('getReportPublishStatus');
+      expect(smartsheet.reports).toHaveProperty('getReportPath');
     });
 
     it('should have create methods', () => {
@@ -314,13 +316,14 @@ describe('Client Unit Tests', () => {
   describe('#Sights', () => {
     it('should have Sights object', () => {
       expect(smartsheet).toHaveProperty('sights');
-      expect(Object.keys(smartsheet.sights)).toHaveLength(8);
+      expect(Object.keys(smartsheet.sights)).toHaveLength(9);
     });
 
     it('should have Sights get methods', () => {
       expect(smartsheet.sights).toHaveProperty('getSight');
       expect(smartsheet.sights).toHaveProperty('listSights');
       expect(smartsheet.sights).toHaveProperty('getSightPublishStatus');
+      expect(smartsheet.sights).toHaveProperty('getSightPath');
     });
 
     it('should have Sights update methods', () => {

--- a/test/mock-api/folders/common_test_constants.ts
+++ b/test/mock-api/folders/common_test_constants.ts
@@ -1,3 +1,9 @@
+// Common Workspace Properties (used for path tests)
+export const TEST_PATH_WORKSPACE_ID = 4509918431602564;
+export const TEST_PATH_WORKSPACE_NAME = 'Sample Workspace';
+export const TEST_PATH_WORKSPACE_PERMALINK =
+    'https://api.smartsheet.com/workspaces/cpG82pf5v8FPrgFfJrFcrM56xCHVGhmV4P4xcQ71';
+
 // Common Folder IDs
 export const TEST_FOLDER_ID = 7116448184199044;
 export const TEST_CHILD_FOLDER_ID_1 = 1234567890123456;

--- a/test/mock-api/folders/common_test_constants.ts
+++ b/test/mock-api/folders/common_test_constants.ts
@@ -2,7 +2,7 @@
 export const TEST_PATH_WORKSPACE_ID = 4509918431602564;
 export const TEST_PATH_WORKSPACE_NAME = 'Sample Workspace';
 export const TEST_PATH_WORKSPACE_PERMALINK =
-    'https://api.smartsheet.com/workspaces/cpG82pf5v8FPrgFfJrFcrM56xCHVGhmV4P4xcQ71';
+    'https://app.smartsheet.com/workspaces/mock_workspace_id';
 
 // Common Folder IDs
 export const TEST_FOLDER_ID = 7116448184199044;

--- a/test/mock-api/folders/get_folder_path.spec.ts
+++ b/test/mock-api/folders/get_folder_path.spec.ts
@@ -117,13 +117,13 @@ describe('Folders - getFolderPath endpoint tests', () => {
         const response = await client.folders.getFolderPath(options);
 
         expect(response).toBeInstanceOf(FolderPathNode);
-        expect(response.getFolder()).toEqual({
+        expect(response.getLeafFolder()).toEqual({
             id: 3456789012345678,
             name: 'Project Plans Sub-Subfolder',
             permalink: 'https://app.smartsheet.com/folders/3456789012345678',
         });
-        expect(response.getFolderPath()).toEqual(
-            'Sample Workspace/Project Plans/Project Plans Subfolder/Project Plans Sub-Subfolder'
+        expect(response.getLeafFolderPath()).toEqual(
+            '/Sample Workspace/Project Plans/Project Plans Subfolder/Project Plans Sub-Subfolder'
         );
     });
 

--- a/test/mock-api/folders/get_folder_path.spec.ts
+++ b/test/mock-api/folders/get_folder_path.spec.ts
@@ -12,7 +12,7 @@ import {
     ERROR_400_MESSAGE,
 } from './common_test_constants';
 import { APIAccessLevel } from '@smartsheet/types';
-import { getLeafFolder, getLeafFolderPath } from '@smartsheet/folders/types';
+import { getLeafFolder, getLeafFolderPath } from '@smartsheet/folders/helpers';
 
 describe('Folders - getFolderPath endpoint tests', () => {
     const client = createClient();

--- a/test/mock-api/folders/get_folder_path.spec.ts
+++ b/test/mock-api/folders/get_folder_path.spec.ts
@@ -12,7 +12,7 @@ import {
     ERROR_400_MESSAGE,
 } from './common_test_constants';
 import { APIAccessLevel } from '@smartsheet/types';
-import { FolderPathNode } from '@smartsheet/folders/types';
+import { getLeafFolder, getLeafFolderPath } from '@smartsheet/folders/types';
 
 describe('Folders - getFolderPath endpoint tests', () => {
     const client = createClient();
@@ -105,7 +105,7 @@ describe('Folders - getFolderPath endpoint tests', () => {
         });
     });
 
-    it('getFolderPath returns FolderPathNode instance with getFolder and getFolderPath methods', async () => {
+    it('getFolderPath returns FolderPathNode compatible with getLeafFolder and getLeafFolderPath', async () => {
         const requestId = crypto.randomUUID();
         const options = {
             folderId: TEST_FOLDER_ID,
@@ -116,13 +116,12 @@ describe('Folders - getFolderPath endpoint tests', () => {
         };
         const response = await client.folders.getFolderPath(options);
 
-        expect(response).toBeInstanceOf(FolderPathNode);
-        expect(response.getLeafFolder()).toEqual({
+        expect(getLeafFolder(response)).toEqual({
             id: 3456789012345678,
             name: 'Project Plans Sub-Subfolder',
             permalink: 'https://app.smartsheet.com/folders/3456789012345678',
         });
-        expect(response.getLeafFolderPath()).toEqual(
+        expect(getLeafFolderPath(response)).toEqual(
             '/Sample Workspace/Project Plans/Project Plans Subfolder/Project Plans Sub-Subfolder'
         );
     });

--- a/test/mock-api/folders/get_folder_path.spec.ts
+++ b/test/mock-api/folders/get_folder_path.spec.ts
@@ -1,0 +1,165 @@
+import crypto from 'crypto';
+import { createClient, findWireMockRequest } from '../utils/utils';
+import { expect } from '@jest/globals';
+import {
+    TEST_FOLDER_ID,
+    TEST_PATH_WORKSPACE_ID,
+    TEST_PATH_WORKSPACE_NAME,
+    TEST_PATH_WORKSPACE_PERMALINK,
+    ERROR_500_STATUS_CODE,
+    ERROR_500_MESSAGE,
+    ERROR_400_STATUS_CODE,
+    ERROR_400_MESSAGE,
+} from './common_test_constants';
+import { APIAccessLevel } from '@smartsheet/types';
+import { FolderPathNode } from '@smartsheet/folders/types';
+
+describe('Folders - getFolderPath endpoint tests', () => {
+    const client = createClient();
+
+    it('getFolderPath generated url is correct', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            folderId: TEST_FOLDER_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/folders/get-nested-folder-path/all-response-body-properties',
+            },
+        };
+        await client.folders.getFolderPath(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+        const parsedUrl = new URL(matchedRequest.absoluteUrl);
+        expect(parsedUrl.pathname).toEqual(`/2.0/folders/${TEST_FOLDER_ID}/path`);
+        expect(matchedRequest.method).toEqual('GET');
+        const queryParamsObject = Object.fromEntries(parsedUrl.searchParams);
+        expect(queryParamsObject).toEqual({});
+    });
+
+    it('getFolderPath all response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            folderId: TEST_FOLDER_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/folders/get-nested-folder-path/all-response-body-properties',
+            },
+        };
+        const response = await client.folders.getFolderPath(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(matchedRequest.body).toEqual('');
+        expect(response).toEqual({
+            id: TEST_PATH_WORKSPACE_ID,
+            name: TEST_PATH_WORKSPACE_NAME,
+            permalink: TEST_PATH_WORKSPACE_PERMALINK,
+            accessLevel: APIAccessLevel.owner,
+            folders: [
+                {
+                    id: 1234567890123456,
+                    name: 'Project Plans',
+                    permalink: 'https://app.smartsheet.com/folders/1234567890123456',
+                    folders: [
+                        {
+                            id: 2345678901234567,
+                            name: 'Project Plans Subfolder',
+                            permalink: 'https://app.smartsheet.com/folders/2345678901234567',
+                            folders: [
+                                {
+                                    id: 3456789012345678,
+                                    name: 'Project Plans Sub-Subfolder',
+                                    permalink: 'https://app.smartsheet.com/folders/3456789012345678',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('getFolderPath root level response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            folderId: TEST_FOLDER_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/folders/get-root-folder-path/all-response-body-properties',
+            },
+        };
+        const response = await client.folders.getFolderPath(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(matchedRequest.body).toEqual('');
+        expect(response).toEqual({
+            id: TEST_PATH_WORKSPACE_ID,
+            name: TEST_PATH_WORKSPACE_NAME,
+            permalink: TEST_PATH_WORKSPACE_PERMALINK,
+            accessLevel: APIAccessLevel.owner,
+            folders: [
+                {
+                    id: 5678901234567890,
+                    name: 'Root Level Folder',
+                    permalink: 'https://app.smartsheet.com/folders/rootlevel',
+                },
+            ],
+        });
+    });
+
+    it('getFolderPath returns FolderPathNode instance with getFolder and getFolderPath methods', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            folderId: TEST_FOLDER_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/folders/get-nested-folder-path/all-response-body-properties',
+            },
+        };
+        const response = await client.folders.getFolderPath(options);
+
+        expect(response).toBeInstanceOf(FolderPathNode);
+        expect(response.getFolder()).toEqual({
+            id: 3456789012345678,
+            name: 'Project Plans Sub-Subfolder',
+            permalink: 'https://app.smartsheet.com/folders/3456789012345678',
+        });
+        expect(response.getFolderPath()).toEqual(
+            'Sample Workspace/Project Plans/Project Plans Subfolder/Project Plans Sub-Subfolder'
+        );
+    });
+
+    it('getFolderPath error 500 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            folderId: TEST_FOLDER_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/500-response',
+            },
+        };
+        try {
+            await client.folders.getFolderPath(options);
+            expect(true).toBe(false);
+        } catch (error: any) {
+            expect(error.statusCode).toBe(ERROR_500_STATUS_CODE);
+            expect(error.message).toBe(ERROR_500_MESSAGE);
+        }
+    });
+
+    it('getFolderPath error 400 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            folderId: TEST_FOLDER_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/400-response',
+            },
+        };
+        try {
+            await client.folders.getFolderPath(options);
+            expect(true).toBe(false);
+        } catch (error: any) {
+            expect(error.statusCode).toBe(ERROR_400_STATUS_CODE);
+            expect(error.message).toBe(ERROR_400_MESSAGE);
+        }
+    });
+});

--- a/test/mock-api/reports/common_test_constants.ts
+++ b/test/mock-api/reports/common_test_constants.ts
@@ -4,7 +4,7 @@ import { ReportColumnType } from '@smartsheet/reports/types';
 export const TEST_PATH_WORKSPACE_ID = 4509918431602564;
 export const TEST_PATH_WORKSPACE_NAME = 'Sample Workspace';
 export const TEST_PATH_WORKSPACE_PERMALINK =
-    'https://api.smartsheet.com/workspaces/cpG82pf5v8FPrgFfJrFcrM56xCHVGhmV4P4xcQ71';
+    'https://app.smartsheet.com/workspaces/mock_workspace_id';
 
 // Common Path Timestamps
 export const TEST_REPORT_CREATED_AT = '2024-01-01T00:00:00Z';

--- a/test/mock-api/reports/common_test_constants.ts
+++ b/test/mock-api/reports/common_test_constants.ts
@@ -1,5 +1,15 @@
 import { ReportColumnType } from '@smartsheet/reports/types';
 
+// Common Workspace Properties (used for path tests)
+export const TEST_PATH_WORKSPACE_ID = 4509918431602564;
+export const TEST_PATH_WORKSPACE_NAME = 'Sample Workspace';
+export const TEST_PATH_WORKSPACE_PERMALINK =
+    'https://api.smartsheet.com/workspaces/cpG82pf5v8FPrgFfJrFcrM56xCHVGhmV4P4xcQ71';
+
+// Common Path Timestamps
+export const TEST_REPORT_CREATED_AT = '2024-01-01T00:00:00Z';
+export const TEST_REPORT_MODIFIED_AT = '2024-06-01T00:00:00Z';
+
 // Common Report IDs
 export const TEST_REPORT_ID = 4583173393803140;
 

--- a/test/mock-api/reports/get_report_path.spec.ts
+++ b/test/mock-api/reports/get_report_path.spec.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import { createClient, findWireMockRequest } from '../utils/utils';
 import { expect } from '@jest/globals';
 import { APIAccessLevel } from '@smartsheet/types';
-import { getLeafReport, getLeafReportPath } from '@smartsheet/reports/types';
+import { getLeafReport, getLeafReportPath } from '@smartsheet/reports/helpers';
 import {
     TEST_REPORT_ID,
     TEST_REPORT_CREATED_AT,

--- a/test/mock-api/reports/get_report_path.spec.ts
+++ b/test/mock-api/reports/get_report_path.spec.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import { createClient, findWireMockRequest } from '../utils/utils';
 import { expect } from '@jest/globals';
 import { APIAccessLevel } from '@smartsheet/types';
+import { getLeafReport, getLeafReportPath } from '@smartsheet/reports/types';
 import {
     TEST_REPORT_ID,
     TEST_REPORT_CREATED_AT,
@@ -14,7 +15,6 @@ import {
     ERROR_400_STATUS_CODE,
     ERROR_400_MESSAGE,
 } from './common_test_constants';
-import { ReportPathNode } from '@smartsheet/reports/types';
 
 describe('Reports - getReportPath endpoint tests', () => {
     const client = createClient();
@@ -113,7 +113,7 @@ describe('Reports - getReportPath endpoint tests', () => {
         });
     });
 
-    it('getReportPath returns ReportPathNode instance with getReport and getReportPath methods', async () => {
+    it('getReportPath returns ReportPathNode compatible with getLeafReport and getLeafReportPath', async () => {
         const requestId = crypto.randomUUID();
         const options = {
             reportId: TEST_REPORT_ID,
@@ -124,8 +124,7 @@ describe('Reports - getReportPath endpoint tests', () => {
         };
         const response = await client.reports.getReportPath(options);
 
-        expect(response).toBeInstanceOf(ReportPathNode);
-        expect(response.getLeafReport()).toEqual({
+        expect(getLeafReport(response)).toEqual({
             id: 3456789012345678,
             name: 'Project Report',
             permalink: 'https://app.smartsheet.com/reports/3456789012345678',
@@ -133,7 +132,7 @@ describe('Reports - getReportPath endpoint tests', () => {
             createdAt: TEST_REPORT_CREATED_AT,
             modifiedAt: TEST_REPORT_MODIFIED_AT,
         });
-        expect(response.getLeafReportPath()).toEqual('/Sample Workspace/Project Plans/Project Report');
+        expect(getLeafReportPath(response)).toEqual('/Sample Workspace/Project Plans/Project Report');
     });
 
     it('getReportPath error 500 response', async () => {

--- a/test/mock-api/reports/get_report_path.spec.ts
+++ b/test/mock-api/reports/get_report_path.spec.ts
@@ -125,7 +125,7 @@ describe('Reports - getReportPath endpoint tests', () => {
         const response = await client.reports.getReportPath(options);
 
         expect(response).toBeInstanceOf(ReportPathNode);
-        expect(response.getReport()).toEqual({
+        expect(response.getLeafReport()).toEqual({
             id: 3456789012345678,
             name: 'Project Report',
             permalink: 'https://app.smartsheet.com/reports/3456789012345678',
@@ -133,7 +133,7 @@ describe('Reports - getReportPath endpoint tests', () => {
             createdAt: TEST_REPORT_CREATED_AT,
             modifiedAt: TEST_REPORT_MODIFIED_AT,
         });
-        expect(response.getReportPath()).toEqual('Sample Workspace/Project Plans/Project Report');
+        expect(response.getLeafReportPath()).toEqual('/Sample Workspace/Project Plans/Project Report');
     });
 
     it('getReportPath error 500 response', async () => {

--- a/test/mock-api/reports/get_report_path.spec.ts
+++ b/test/mock-api/reports/get_report_path.spec.ts
@@ -1,0 +1,174 @@
+import crypto from 'crypto';
+import { createClient, findWireMockRequest } from '../utils/utils';
+import { expect } from '@jest/globals';
+import { APIAccessLevel } from '@smartsheet/types';
+import {
+    TEST_REPORT_ID,
+    TEST_REPORT_CREATED_AT,
+    TEST_REPORT_MODIFIED_AT,
+    TEST_PATH_WORKSPACE_ID,
+    TEST_PATH_WORKSPACE_NAME,
+    TEST_PATH_WORKSPACE_PERMALINK,
+    ERROR_500_STATUS_CODE,
+    ERROR_500_MESSAGE,
+    ERROR_400_STATUS_CODE,
+    ERROR_400_MESSAGE,
+} from './common_test_constants';
+import { ReportPathNode } from '@smartsheet/reports/types';
+
+describe('Reports - getReportPath endpoint tests', () => {
+    const client = createClient();
+
+    it('getReportPath generated url is correct', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/get-nested-report-path/all-response-body-properties',
+            },
+        };
+        await client.reports.getReportPath(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+        const parsedUrl = new URL(matchedRequest.absoluteUrl);
+        expect(parsedUrl.pathname).toEqual(`/2.0/reports/${TEST_REPORT_ID}/path`);
+        expect(matchedRequest.method).toEqual('GET');
+        const queryParamsObject = Object.fromEntries(parsedUrl.searchParams);
+        expect(queryParamsObject).toEqual({});
+    });
+
+    it('getReportPath all response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/get-nested-report-path/all-response-body-properties',
+            },
+        };
+        const response = await client.reports.getReportPath(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(matchedRequest.body).toEqual('');
+        expect(response).toEqual({
+            id: TEST_PATH_WORKSPACE_ID,
+            name: TEST_PATH_WORKSPACE_NAME,
+            permalink: TEST_PATH_WORKSPACE_PERMALINK,
+            accessLevel: APIAccessLevel.owner,
+            folders: [
+                {
+                    id: 1234567890123456,
+                    name: 'Project Plans',
+                    permalink: 'https://app.smartsheet.com/folders/1234567890123456',
+                    folders: [
+                        {
+                            id: 2345678901234567,
+                            name: 'Project Plans Subfolder',
+                            permalink: 'https://app.smartsheet.com/folders/2345678901234567',
+                            reports: [
+                                {
+                                    id: 3456789012345678,
+                                    name: 'Project Report',
+                                    permalink: 'https://app.smartsheet.com/reports/3456789012345678',
+                                    accessLevel: APIAccessLevel.admin,
+                                    createdAt: TEST_REPORT_CREATED_AT,
+                                    modifiedAt: TEST_REPORT_MODIFIED_AT,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('getReportPath root level response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/get-root-report-path/all-response-body-properties',
+            },
+        };
+        const response = await client.reports.getReportPath(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(matchedRequest.body).toEqual('');
+        expect(response).toEqual({
+            id: TEST_PATH_WORKSPACE_ID,
+            name: TEST_PATH_WORKSPACE_NAME,
+            permalink: TEST_PATH_WORKSPACE_PERMALINK,
+            accessLevel: APIAccessLevel.owner,
+            reports: [
+                {
+                    id: 5678901234567890,
+                    name: 'Root Level Report',
+                    permalink: 'https://app.smartsheet.com/reports/rootlevel',
+                    accessLevel: APIAccessLevel.admin,
+                    createdAt: TEST_REPORT_CREATED_AT,
+                    modifiedAt: TEST_REPORT_MODIFIED_AT,
+                },
+            ],
+        });
+    });
+
+    it('getReportPath returns ReportPathNode instance with getReport and getReportPath methods', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/reports/get-nested-report-path/all-response-body-properties',
+            },
+        };
+        const response = await client.reports.getReportPath(options);
+
+        expect(response).toBeInstanceOf(ReportPathNode);
+        expect(response.getReport()).toEqual({
+            id: 3456789012345678,
+            name: 'Project Report',
+            permalink: 'https://app.smartsheet.com/reports/3456789012345678',
+            accessLevel: APIAccessLevel.admin,
+            createdAt: TEST_REPORT_CREATED_AT,
+            modifiedAt: TEST_REPORT_MODIFIED_AT,
+        });
+        expect(response.getReportPath()).toEqual('Sample Workspace/Project Plans/Project Report');
+    });
+
+    it('getReportPath error 500 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/500-response',
+            },
+        };
+        try {
+            await client.reports.getReportPath(options);
+            expect(true).toBe(false);
+        } catch (error: any) {
+            expect(error.statusCode).toBe(ERROR_500_STATUS_CODE);
+            expect(error.message).toBe(ERROR_500_MESSAGE);
+        }
+    });
+
+    it('getReportPath error 400 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            reportId: TEST_REPORT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/400-response',
+            },
+        };
+        try {
+            await client.reports.getReportPath(options);
+            expect(true).toBe(false);
+        } catch (error: any) {
+            expect(error.statusCode).toBe(ERROR_400_STATUS_CODE);
+            expect(error.message).toBe(ERROR_400_MESSAGE);
+        }
+    });
+});

--- a/test/mock-api/sheets/common_test_constants.ts
+++ b/test/mock-api/sheets/common_test_constants.ts
@@ -1,0 +1,16 @@
+// Common Workspace Properties (used for path tests)
+export const TEST_PATH_WORKSPACE_ID = 4509918431602564;
+export const TEST_PATH_WORKSPACE_NAME = 'Sample Workspace';
+export const TEST_PATH_WORKSPACE_PERMALINK =
+    'https://api.smartsheet.com/workspaces/cpG82pf5v8FPrgFfJrFcrM56xCHVGhmV4P4xcQ71';
+
+// Common Sheet Data
+export const TEST_SHEET_ID = 9876543210987654;
+export const TEST_SHEET_CREATED_AT = '2024-01-01T00:00:00Z';
+export const TEST_SHEET_MODIFIED_AT = '2024-06-01T00:00:00Z';
+
+// Common Error Status Codes
+export const ERROR_500_STATUS_CODE = 500;
+export const ERROR_500_MESSAGE = 'Internal Server Error';
+export const ERROR_400_STATUS_CODE = 400;
+export const ERROR_400_MESSAGE = 'Malformed Request';

--- a/test/mock-api/sheets/common_test_constants.ts
+++ b/test/mock-api/sheets/common_test_constants.ts
@@ -2,7 +2,7 @@
 export const TEST_PATH_WORKSPACE_ID = 4509918431602564;
 export const TEST_PATH_WORKSPACE_NAME = 'Sample Workspace';
 export const TEST_PATH_WORKSPACE_PERMALINK =
-    'https://api.smartsheet.com/workspaces/cpG82pf5v8FPrgFfJrFcrM56xCHVGhmV4P4xcQ71';
+    'https://app.smartsheet.com/workspaces/mock_workspace_id';
 
 // Common Sheet Data
 export const TEST_SHEET_ID = 9876543210987654;

--- a/test/mock-api/sheets/get_sheet_path.spec.ts
+++ b/test/mock-api/sheets/get_sheet_path.spec.ts
@@ -125,7 +125,7 @@ describe('Sheets - getSheetPath endpoint tests', () => {
         const response = await client.sheets.getSheetPath(options);
 
         expect(response).toBeInstanceOf(SheetPathNode);
-        expect(response.getSheet()).toEqual({
+        expect(response.getLeafSheet()).toEqual({
             id: 3456789012345678,
             name: 'Project Plan',
             permalink: 'https://app.smartsheet.com/sheets/3456789012345678',
@@ -133,7 +133,7 @@ describe('Sheets - getSheetPath endpoint tests', () => {
             createdAt: TEST_SHEET_CREATED_AT,
             modifiedAt: TEST_SHEET_MODIFIED_AT,
         });
-        expect(response.getSheetPath()).toEqual('Sample Workspace/Project Plans/Project Plan');
+        expect(response.getLeafSheetPath()).toEqual('/Sample Workspace/Project Plans/Project Plan');
     });
 
     it('getSheetPath error 500 response', async () => {

--- a/test/mock-api/sheets/get_sheet_path.spec.ts
+++ b/test/mock-api/sheets/get_sheet_path.spec.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import { createClient, findWireMockRequest } from '../utils/utils';
 import { expect } from '@jest/globals';
 import { APIAccessLevel } from '@smartsheet/types';
-import { SheetPathNode } from '@smartsheet/sheets/types';
+import { getLeafSheet, getLeafSheetPath } from '@smartsheet/sheets/types';
 import {
     TEST_SHEET_ID,
     TEST_SHEET_CREATED_AT,
@@ -113,7 +113,7 @@ describe('Sheets - getSheetPath endpoint tests', () => {
         });
     });
 
-    it('getSheetPath returns SheetPathNode instance with getSheet and getSheetPath methods', async () => {
+    it('getSheetPath returns SheetPathNode compatible with getLeafSheet and getLeafSheetPath', async () => {
         const requestId = crypto.randomUUID();
         const options = {
             sheetId: TEST_SHEET_ID,
@@ -124,8 +124,7 @@ describe('Sheets - getSheetPath endpoint tests', () => {
         };
         const response = await client.sheets.getSheetPath(options);
 
-        expect(response).toBeInstanceOf(SheetPathNode);
-        expect(response.getLeafSheet()).toEqual({
+        expect(getLeafSheet(response)).toEqual({
             id: 3456789012345678,
             name: 'Project Plan',
             permalink: 'https://app.smartsheet.com/sheets/3456789012345678',
@@ -133,7 +132,7 @@ describe('Sheets - getSheetPath endpoint tests', () => {
             createdAt: TEST_SHEET_CREATED_AT,
             modifiedAt: TEST_SHEET_MODIFIED_AT,
         });
-        expect(response.getLeafSheetPath()).toEqual('/Sample Workspace/Project Plans/Project Plan');
+        expect(getLeafSheetPath(response)).toEqual('/Sample Workspace/Project Plans/Project Plan');
     });
 
     it('getSheetPath error 500 response', async () => {

--- a/test/mock-api/sheets/get_sheet_path.spec.ts
+++ b/test/mock-api/sheets/get_sheet_path.spec.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import { createClient, findWireMockRequest } from '../utils/utils';
 import { expect } from '@jest/globals';
 import { APIAccessLevel } from '@smartsheet/types';
-import { getLeafSheet, getLeafSheetPath } from '@smartsheet/sheets/types';
+import { getLeafSheet, getLeafSheetPath } from '@smartsheet/sheets/helpers';
 import {
     TEST_SHEET_ID,
     TEST_SHEET_CREATED_AT,

--- a/test/mock-api/sheets/get_sheet_path.spec.ts
+++ b/test/mock-api/sheets/get_sheet_path.spec.ts
@@ -1,0 +1,174 @@
+import crypto from 'crypto';
+import { createClient, findWireMockRequest } from '../utils/utils';
+import { expect } from '@jest/globals';
+import { APIAccessLevel } from '@smartsheet/types';
+import { SheetPathNode } from '@smartsheet/sheets/types';
+import {
+    TEST_SHEET_ID,
+    TEST_SHEET_CREATED_AT,
+    TEST_SHEET_MODIFIED_AT,
+    TEST_PATH_WORKSPACE_ID,
+    TEST_PATH_WORKSPACE_NAME,
+    TEST_PATH_WORKSPACE_PERMALINK,
+    ERROR_500_STATUS_CODE,
+    ERROR_500_MESSAGE,
+    ERROR_400_STATUS_CODE,
+    ERROR_400_MESSAGE,
+} from './common_test_constants';
+
+describe('Sheets - getSheetPath endpoint tests', () => {
+    const client = createClient();
+
+    it('getSheetPath generated url is correct', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            sheetId: TEST_SHEET_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/sheets/get-nested-sheet-path/all-response-body-properties',
+            },
+        };
+        await client.sheets.getSheetPath(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+        const parsedUrl = new URL(matchedRequest.absoluteUrl);
+        expect(parsedUrl.pathname).toEqual(`/2.0/sheets/${TEST_SHEET_ID}/path`);
+        expect(matchedRequest.method).toEqual('GET');
+        const queryParamsObject = Object.fromEntries(parsedUrl.searchParams);
+        expect(queryParamsObject).toEqual({});
+    });
+
+    it('getSheetPath all response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            sheetId: TEST_SHEET_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/sheets/get-nested-sheet-path/all-response-body-properties',
+            },
+        };
+        const response = await client.sheets.getSheetPath(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(matchedRequest.body).toEqual('');
+        expect(response).toEqual({
+            id: TEST_PATH_WORKSPACE_ID,
+            name: TEST_PATH_WORKSPACE_NAME,
+            permalink: TEST_PATH_WORKSPACE_PERMALINK,
+            accessLevel: APIAccessLevel.owner,
+            folders: [
+                {
+                    id: 1234567890123456,
+                    name: 'Project Plans',
+                    permalink: 'https://app.smartsheet.com/folders/1234567890123456',
+                    folders: [
+                        {
+                            id: 2345678901234567,
+                            name: 'Project Plans Subfolder',
+                            permalink: 'https://app.smartsheet.com/folders/2345678901234567',
+                            sheets: [
+                                {
+                                    id: 3456789012345678,
+                                    name: 'Project Plan',
+                                    permalink: 'https://app.smartsheet.com/sheets/3456789012345678',
+                                    accessLevel: APIAccessLevel.admin,
+                                    createdAt: TEST_SHEET_CREATED_AT,
+                                    modifiedAt: TEST_SHEET_MODIFIED_AT,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('getSheetPath root level response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            sheetId: TEST_SHEET_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/sheets/get-root-sheet-path/all-response-body-properties',
+            },
+        };
+        const response = await client.sheets.getSheetPath(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(matchedRequest.body).toEqual('');
+        expect(response).toEqual({
+            id: TEST_PATH_WORKSPACE_ID,
+            name: TEST_PATH_WORKSPACE_NAME,
+            permalink: TEST_PATH_WORKSPACE_PERMALINK,
+            accessLevel: APIAccessLevel.owner,
+            sheets: [
+                {
+                    id: 5678901234567890,
+                    name: 'Root Level Sheet',
+                    permalink: 'https://app.smartsheet.com/sheets/rootlevel',
+                    accessLevel: APIAccessLevel.admin,
+                    createdAt: TEST_SHEET_CREATED_AT,
+                    modifiedAt: TEST_SHEET_MODIFIED_AT,
+                },
+            ],
+        });
+    });
+
+    it('getSheetPath returns SheetPathNode instance with getSheet and getSheetPath methods', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            sheetId: TEST_SHEET_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/sheets/get-nested-sheet-path/all-response-body-properties',
+            },
+        };
+        const response = await client.sheets.getSheetPath(options);
+
+        expect(response).toBeInstanceOf(SheetPathNode);
+        expect(response.getSheet()).toEqual({
+            id: 3456789012345678,
+            name: 'Project Plan',
+            permalink: 'https://app.smartsheet.com/sheets/3456789012345678',
+            accessLevel: APIAccessLevel.admin,
+            createdAt: TEST_SHEET_CREATED_AT,
+            modifiedAt: TEST_SHEET_MODIFIED_AT,
+        });
+        expect(response.getSheetPath()).toEqual('Sample Workspace/Project Plans/Project Plan');
+    });
+
+    it('getSheetPath error 500 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            sheetId: TEST_SHEET_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/500-response',
+            },
+        };
+        try {
+            await client.sheets.getSheetPath(options);
+            expect(true).toBe(false);
+        } catch (error: any) {
+            expect(error.statusCode).toBe(ERROR_500_STATUS_CODE);
+            expect(error.message).toBe(ERROR_500_MESSAGE);
+        }
+    });
+
+    it('getSheetPath error 400 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            sheetId: TEST_SHEET_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/400-response',
+            },
+        };
+        try {
+            await client.sheets.getSheetPath(options);
+            expect(true).toBe(false);
+        } catch (error: any) {
+            expect(error.statusCode).toBe(ERROR_400_STATUS_CODE);
+            expect(error.message).toBe(ERROR_400_MESSAGE);
+        }
+    });
+});

--- a/test/mock-api/sights/common_test_constants.ts
+++ b/test/mock-api/sights/common_test_constants.ts
@@ -2,7 +2,7 @@
 export const TEST_PATH_WORKSPACE_ID = 4509918431602564;
 export const TEST_PATH_WORKSPACE_NAME = 'Sample Workspace';
 export const TEST_PATH_WORKSPACE_PERMALINK =
-    'https://api.smartsheet.com/workspaces/cpG82pf5v8FPrgFfJrFcrM56xCHVGhmV4P4xcQ71';
+    'https://app.smartsheet.com/workspaces/mock_workspace_id';
 
 // Common Sight IDs
 export const TEST_SIGHT_ID = 9876543210123456;

--- a/test/mock-api/sights/common_test_constants.ts
+++ b/test/mock-api/sights/common_test_constants.ts
@@ -1,0 +1,16 @@
+// Common Workspace Properties (used for path tests)
+export const TEST_PATH_WORKSPACE_ID = 4509918431602564;
+export const TEST_PATH_WORKSPACE_NAME = 'Sample Workspace';
+export const TEST_PATH_WORKSPACE_PERMALINK =
+    'https://api.smartsheet.com/workspaces/cpG82pf5v8FPrgFfJrFcrM56xCHVGhmV4P4xcQ71';
+
+// Common Sight IDs
+export const TEST_SIGHT_ID = 9876543210123456;
+export const TEST_SIGHT_CREATED_AT = '2024-01-01T00:00:00Z';
+export const TEST_SIGHT_MODIFIED_AT = '2024-06-01T00:00:00Z';
+
+// Common Error Status Codes
+export const ERROR_500_STATUS_CODE = 500;
+export const ERROR_500_MESSAGE = 'Internal Server Error';
+export const ERROR_400_STATUS_CODE = 400;
+export const ERROR_400_MESSAGE = 'Malformed Request';

--- a/test/mock-api/sights/get_sight_path.spec.ts
+++ b/test/mock-api/sights/get_sight_path.spec.ts
@@ -125,7 +125,7 @@ describe('Sights - getSightPath endpoint tests', () => {
         const response = await client.sights.getSightPath(options);
 
         expect(response).toBeInstanceOf(SightPathNode);
-        expect(response.getSight()).toEqual({
+        expect(response.getLeafSight()).toEqual({
             id: 3456789012345678,
             name: 'Project Dashboard',
             permalink: 'https://app.smartsheet.com/dashboards/3456789012345678',
@@ -133,7 +133,7 @@ describe('Sights - getSightPath endpoint tests', () => {
             createdAt: TEST_SIGHT_CREATED_AT,
             modifiedAt: TEST_SIGHT_MODIFIED_AT,
         });
-        expect(response.getSightPath()).toEqual('Sample Workspace/Project Plans/Project Dashboard');
+        expect(response.getLeafSightPath()).toEqual('/Sample Workspace/Project Plans/Project Dashboard');
     });
 
     it('getSightPath error 500 response', async () => {

--- a/test/mock-api/sights/get_sight_path.spec.ts
+++ b/test/mock-api/sights/get_sight_path.spec.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import { createClient, findWireMockRequest } from '../utils/utils';
 import { expect } from '@jest/globals';
 import { APIAccessLevel } from '@smartsheet/types';
-import { getLeafSight, getLeafSightPath } from '@smartsheet/sights/types';
+import { getLeafSight, getLeafSightPath } from '@smartsheet/sights/helpers';
 import {
     TEST_SIGHT_ID,
     TEST_SIGHT_CREATED_AT,

--- a/test/mock-api/sights/get_sight_path.spec.ts
+++ b/test/mock-api/sights/get_sight_path.spec.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import { createClient, findWireMockRequest } from '../utils/utils';
 import { expect } from '@jest/globals';
 import { APIAccessLevel } from '@smartsheet/types';
-import { SightPathNode } from '@smartsheet/sights/types';
+import { getLeafSight, getLeafSightPath } from '@smartsheet/sights/types';
 import {
     TEST_SIGHT_ID,
     TEST_SIGHT_CREATED_AT,
@@ -113,7 +113,7 @@ describe('Sights - getSightPath endpoint tests', () => {
         });
     });
 
-    it('getSightPath returns SightPathNode instance with getSight and getSightPath methods', async () => {
+    it('getSightPath returns SightPathNode compatible with getLeafSight and getLeafSightPath', async () => {
         const requestId = crypto.randomUUID();
         const options = {
             sightId: TEST_SIGHT_ID,
@@ -124,8 +124,7 @@ describe('Sights - getSightPath endpoint tests', () => {
         };
         const response = await client.sights.getSightPath(options);
 
-        expect(response).toBeInstanceOf(SightPathNode);
-        expect(response.getLeafSight()).toEqual({
+        expect(getLeafSight(response)).toEqual({
             id: 3456789012345678,
             name: 'Project Dashboard',
             permalink: 'https://app.smartsheet.com/dashboards/3456789012345678',
@@ -133,7 +132,7 @@ describe('Sights - getSightPath endpoint tests', () => {
             createdAt: TEST_SIGHT_CREATED_AT,
             modifiedAt: TEST_SIGHT_MODIFIED_AT,
         });
-        expect(response.getLeafSightPath()).toEqual('/Sample Workspace/Project Plans/Project Dashboard');
+        expect(getLeafSightPath(response)).toEqual('/Sample Workspace/Project Plans/Project Dashboard');
     });
 
     it('getSightPath error 500 response', async () => {

--- a/test/mock-api/sights/get_sight_path.spec.ts
+++ b/test/mock-api/sights/get_sight_path.spec.ts
@@ -1,0 +1,174 @@
+import crypto from 'crypto';
+import { createClient, findWireMockRequest } from '../utils/utils';
+import { expect } from '@jest/globals';
+import { APIAccessLevel } from '@smartsheet/types';
+import { SightPathNode } from '@smartsheet/sights/types';
+import {
+    TEST_SIGHT_ID,
+    TEST_SIGHT_CREATED_AT,
+    TEST_SIGHT_MODIFIED_AT,
+    TEST_PATH_WORKSPACE_ID,
+    TEST_PATH_WORKSPACE_NAME,
+    TEST_PATH_WORKSPACE_PERMALINK,
+    ERROR_500_STATUS_CODE,
+    ERROR_500_MESSAGE,
+    ERROR_400_STATUS_CODE,
+    ERROR_400_MESSAGE,
+} from './common_test_constants';
+
+describe('Sights - getSightPath endpoint tests', () => {
+    const client = createClient();
+
+    it('getSightPath generated url is correct', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            sightId: TEST_SIGHT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/sights/get-nested-sight-path/all-response-body-properties',
+            },
+        };
+        await client.sights.getSightPath(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+        const parsedUrl = new URL(matchedRequest.absoluteUrl);
+        expect(parsedUrl.pathname).toEqual(`/2.0/sights/${TEST_SIGHT_ID}/path`);
+        expect(matchedRequest.method).toEqual('GET');
+        const queryParamsObject = Object.fromEntries(parsedUrl.searchParams);
+        expect(queryParamsObject).toEqual({});
+    });
+
+    it('getSightPath all response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            sightId: TEST_SIGHT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/sights/get-nested-sight-path/all-response-body-properties',
+            },
+        };
+        const response = await client.sights.getSightPath(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(matchedRequest.body).toEqual('');
+        expect(response).toEqual({
+            id: TEST_PATH_WORKSPACE_ID,
+            name: TEST_PATH_WORKSPACE_NAME,
+            permalink: TEST_PATH_WORKSPACE_PERMALINK,
+            accessLevel: APIAccessLevel.owner,
+            folders: [
+                {
+                    id: 1234567890123456,
+                    name: 'Project Plans',
+                    permalink: 'https://app.smartsheet.com/folders/1234567890123456',
+                    folders: [
+                        {
+                            id: 2345678901234567,
+                            name: 'Project Plans Subfolder',
+                            permalink: 'https://app.smartsheet.com/folders/2345678901234567',
+                            sights: [
+                                {
+                                    id: 3456789012345678,
+                                    name: 'Project Dashboard',
+                                    permalink: 'https://app.smartsheet.com/dashboards/3456789012345678',
+                                    accessLevel: APIAccessLevel.admin,
+                                    createdAt: TEST_SIGHT_CREATED_AT,
+                                    modifiedAt: TEST_SIGHT_MODIFIED_AT,
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+
+    it('getSightPath root level response body properties', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            sightId: TEST_SIGHT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/sights/get-root-sight-path/all-response-body-properties',
+            },
+        };
+        const response = await client.sights.getSightPath(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+
+        expect(matchedRequest.body).toEqual('');
+        expect(response).toEqual({
+            id: TEST_PATH_WORKSPACE_ID,
+            name: TEST_PATH_WORKSPACE_NAME,
+            permalink: TEST_PATH_WORKSPACE_PERMALINK,
+            accessLevel: APIAccessLevel.owner,
+            sights: [
+                {
+                    id: 5678901234567890,
+                    name: 'Root Level Dashboard',
+                    permalink: 'https://app.smartsheet.com/dashboards/rootlevel',
+                    accessLevel: APIAccessLevel.admin,
+                    createdAt: TEST_SIGHT_CREATED_AT,
+                    modifiedAt: TEST_SIGHT_MODIFIED_AT,
+                },
+            ],
+        });
+    });
+
+    it('getSightPath returns SightPathNode instance with getSight and getSightPath methods', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            sightId: TEST_SIGHT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/sights/get-nested-sight-path/all-response-body-properties',
+            },
+        };
+        const response = await client.sights.getSightPath(options);
+
+        expect(response).toBeInstanceOf(SightPathNode);
+        expect(response.getSight()).toEqual({
+            id: 3456789012345678,
+            name: 'Project Dashboard',
+            permalink: 'https://app.smartsheet.com/dashboards/3456789012345678',
+            accessLevel: APIAccessLevel.admin,
+            createdAt: TEST_SIGHT_CREATED_AT,
+            modifiedAt: TEST_SIGHT_MODIFIED_AT,
+        });
+        expect(response.getSightPath()).toEqual('Sample Workspace/Project Plans/Project Dashboard');
+    });
+
+    it('getSightPath error 500 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            sightId: TEST_SIGHT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/500-response',
+            },
+        };
+        try {
+            await client.sights.getSightPath(options);
+            expect(true).toBe(false);
+        } catch (error: any) {
+            expect(error.statusCode).toBe(ERROR_500_STATUS_CODE);
+            expect(error.message).toBe(ERROR_500_MESSAGE);
+        }
+    });
+
+    it('getSightPath error 400 response', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            sightId: TEST_SIGHT_ID,
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/errors/400-response',
+            },
+        };
+        try {
+            await client.sights.getSightPath(options);
+            expect(true).toBe(false);
+        } catch (error: any) {
+            expect(error.statusCode).toBe(ERROR_400_STATUS_CODE);
+            expect(error.message).toBe(ERROR_400_MESSAGE);
+        }
+    });
+});


### PR DESCRIPTION
# Pull Request

## Description
Added support and WireMock tests for the following endpoints:
- /2.0/folders/{folderId}/path
- /2.0/reports/{reportId}/path
- /2.0/sheets/{sheetId}/path
- /2.0/sights/{sightId}/path


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):