### PR TITLE
docs(events): document and deprecate `objectId` in favor of `objectIdStr` (AUD-907)

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -504,6 +504,18 @@ Note that the `moreAvailable` attribute in a response indicates whether more eve
 
 Many events have additional information available as a part of the event. That information can be accessed from the data stored in the `additionalDetails` attribute. Information about the additional details provided can be found [here](https://smartsheet-platform.github.io/event-reporting-docs/).
 
+Each event identifies the object it affected. Use the `objectIdStr` property, which holds the object identifier as a string and supports both numeric and non-numeric identifiers. The older `objectId` property is deprecated and kept only for backward compatibility: when the identifier is numeric it contains the number, and when the identifier is non-numeric it contains `-1` while the real value is available in `objectIdStr`. New code should read `objectIdStr`.
+
+```javascript
+result.data.forEach((event) => {
+  // Preferred: works for all identifier types
+  console.log(event.objectIdStr);
+
+  // Deprecated: numeric only; returns -1 for non-numeric identifiers
+  // console.log(event.objectId);
+});
+```
+
 
 ```javascript
 // Initialize the client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [X.X.X] - Unreleased
 
+### Deprecated
+
+- Deprecated `Event.objectId`; use `Event.objectIdStr` instead. `objectId` is numeric only and contains -1 for non-numeric identifiers. It is not scheduled for removal.
+
 ## [5.1.0] - 2026-06-26
 
 ### Added

--- a/lib/events/types.ts
+++ b/lib/events/types.ts
@@ -71,6 +71,10 @@ export interface Event {
 
   /**
    * The identifier of the object impacted by the event.
+   *
+   * @deprecated Use {@link Event.objectIdStr} instead. `objectId` is numeric only and
+   * contains -1 for non-numeric identifiers. It is not scheduled for removal, but new
+   * code should read `objectIdStr`, which represents all identifier values.
    */
   objectId: string;
 


### PR DESCRIPTION
## Summary
 
Documents the `objectIdStr` property on the `Event` interface and marks the older numeric `objectId` property as deprecated. The `objectIdStr` property itself was added to the SDK in #177; this PR adds the user-facing documentation and the deprecation marker.
 
`objectIdStr` holds the affected object's identifier as a string and supports both numeric and non-numeric identifiers. The existing numeric `objectId` property is deprecated (kept for backward compatibility) — it contains `-1` when the identifier is non-numeric, in which case the real value is only available in `objectIdStr`. New code should read `objectIdStr`.
 
## Changes
 
- `ADVANCED.md` — add an explanatory paragraph plus a before/after code sample to the Event Reporting section showing `event.objectIdStr` (preferred) vs. `event.objectId` (deprecated).
- `lib/events/types.ts` — add a JSDoc `@deprecated` tag to the `objectId` property in the `Event` interface pointing to `objectIdStr`.
- `CHANGELOG.md` — add a `Deprecated` entry under Unreleased.
## Notes for reviewers
 
- This is a **soft** deprecation. The JSDoc states that `objectId` is *not* scheduled for removal — matching the API changelog (Jun-08-2026). The `@deprecated` tag surfaces as an IDE strikethrough; it has no runtime effect. Please flag if you'd prefer stronger or weaker language.
- The generated `dist/lib/events/types.d.ts` is not edited here — it regenerates from source on build/release.
- Part of AUD-907. Parallel PRs apply the equivalent documentation + deprecation to the Python, Java, and C# SDKs, and a cross-language migration guide is going into `api-docs`.
## Related
 
- Jira: AUD-907
- Code PR: #177 (added the `objectIdStr` field, AUD-903)
 