### PR TITLE
Prepare for release v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [X.X.X] - Unreleased
 
+## [5.1.0] - 2026-06-26
+
 ### Added
 
 - Added support for GET /2.0/sheets/{sheetId}/path endpoint (`getSheetPath`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smartsheet",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smartsheet",
-      "version": "5.0.1",
+      "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Smartsheet JavaScript client SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Release prep for v5.1.0 (minor — all changes additive). Bumps `version` to 5.1.0 in `package.json` and `package-lock.json` (top-level only) and stamps the CHANGELOG `Unreleased` section with `## [5.1.0] - 2026-06-26`.

Released content accumulated on `mainline` since v5.0.1:
- **Added:** GET path endpoints (`getSheetPath`, `getReportPath`, `getSightPath`, `getFolderPath`) with `getLeaf<Asset>()` / `getLeaf<Asset>Path()` traversal helpers.

## Test plan
- [ ] CI build + tests pass on the release branch