### PR TITLE
Prepare for release v5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [X.X.X] - Unreleased
 
+## [5.2.0] - 2026-07-09
+
 ### Added
 - Added support for GET /2.0/reports/{reportId}/scope endpoint (`listReportScope`)
 - Added support for GET /2.0/reports/{reportId}/columns endpoint (`listReportColumns`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smartsheet",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "smartsheet",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.13.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartsheet",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Smartsheet JavaScript client SDK",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
Release prep for v5.1.0 (minor — all changes additive). Bumps version to 5.2.0 in package.json and package-lock.json (top-level only) and stamps the CHANGELOG Unreleased section with ## [5.2.0] - 2026-07-09.

Released content accumulated on mainline since v5.1.0:

Added:
- Added support for GET /2.0/reports/{reportId}/scope endpoint (`listReportScope`)
- Added support for GET /2.0/reports/{reportId}/columns endpoint (`listReportColumns`)
- Added support for GET /2.0/reports/{reportId}/columns/{columnVirtualId} endpoint (`getReportColumn`)
- Added support for PUT /2.0/reports/{reportId}/columns/{columnVirtualId} endpoint (`updateReportColumn`)
- Added support for DELETE /2.0/reports/{reportId}/columns/{columnVirtualId} endpoint (`deleteReportColumn`)
- Added support for GET /2.0/reports/{reportId}/definition endpoint (`getReportDefinition`)

Deprecated:
- Deprecated `Event.ObjectId`; use `Event.ObjectIdStr` instead. `ObjectId` is numeric only and returns -1 for non-numeric identifiers. It is not scheduled for removal.