### PR TITLE
Document proofs include value for getReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [X.X.X] - Unreleased
 
+### Changed
+- Documented `proofs` as a valid `include` value for `getReport`
+
 ## [5.2.0] - 2026-07-09
 
 ### Added

--- a/lib/reports/types.ts
+++ b/lib/reports/types.ts
@@ -1006,7 +1006,8 @@ export interface GetReportQueryParameters {
    */
   accessApiLevel?: number;
   /**
-   * A comma-separated list of optional elements to include in the response
+   * A comma-separated list of optional elements to include in the response.
+   * Valid values: attachments, discussions, proofs, format, objectValue, scope, source, sourceSheets.
    */
   include?: string;
   /**


### PR DESCRIPTION
Documents `proofs` as a valid `include` value on `GetReportQueryParameters.include`, completing the proofs work across the SDKs (Java #186, C# #216, Python #159/#161).

The JS SDK already supported `include=proofs` at runtime (the `include` field is a free-form string and the `Proof` type + `Row.proof` already exist and are reused by report rows) — this is a docs-only JSDoc + CHANGELOG change for discoverability.

DEVECO-2197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the valid values for the `getReport` `include` parameter.
  * Documented support for including proofs, along with attachments, discussions, formatting, object values, scope, source, and source sheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->