### PR TITLE
Bump axios to ^1.18.0 to resolve six security advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [X.X.X] - Unreleased
 
+### Security
+
+- Bumped `axios` to `^1.18.0` to resolve six security advisories (GHSA-gcfj-64vw-6mp9, GHSA-jqh4-m9w3-8hp9, GHSA-hcpx-6fm6-wx23, GHSA-mwf2-3pr3-8698, GHSA-f4gw-2p7v-4548, GHSA-xj6q-8x83-jv6g), all patched in axios 1.18.0.
+
 ### Fixed
 
 - Fixed all `sharing` methods (`listAssetShares`, `getAssetShare`, `shareAsset`, `updateAssetShare`, `deleteAssetShare`) failing with `404 Not Found` because query parameters (`assetType`/`assetId`) were baked into the request URL and then re-applied by the HTTP layer, producing a duplicated, malformed query string. Query parameters are now applied once. ([#195](https://github.com/smartsheet/smartsheet-javascript-sdk/issues/195))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^1.13.5",
+        "axios": "^1.18.0",
         "extend": "^3.0.2",
         "mime": "^3.0.0",
         "underscore": "^1.8.2",
@@ -2695,6 +2695,18 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -2801,13 +2813,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -3389,7 +3402,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4344,6 +4356,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -5940,7 +5965,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "http://developers.smartsheet.com",
   "dependencies": {
-    "axios": "^1.13.5",
+    "axios": "^1.18.0",
     "extend": "^3.0.2",
     "mime": "^3.0.0",
     "underscore": "^1.8.2",


### PR DESCRIPTION
## Summary

- Bumps `axios` from `1.16.0` → `1.18.1` (declared floor raised `^1.13.5` → `^1.18.0`), clearing six open Dependabot alerts, all patched in axios `1.18.0`.
- Raising the declared floor (not just the lockfile) ensures downstream SDK consumers cannot resolve a vulnerable axios version.

### Advisories resolved

| Severity | GHSA | Summary |
|----------|------|---------|
| High | GHSA-gcfj-64vw-6mp9 | Node HTTP adapter can use an inherited proxy after interceptor config cloning |
| Medium | GHSA-jqh4-m9w3-8hp9 | Fetch adapter `ReadableStream` uploads bypass `maxBodyLength` |
| Medium | GHSA-hcpx-6fm6-wx23 | Form serializer `maxDepth` bypass via `{}` metatoken |
| Medium | GHSA-mwf2-3pr3-8698 | HTTP/2 streamed uploads bypass `maxBodyLength` |
| Medium | GHSA-f4gw-2p7v-4548 | `NO_PROXY` bypass for `0.0.0.0` local addresses |
| Medium | GHSA-xj6q-8x83-jv6g | Prototype pollution — auth subfields can inject Basic auth |

axios stays within major v1, so no breaking changes. The SDK's usage in `lib/utils/httpRequestor.js` is standard `get/post/put/patch/delete` and does not touch any of the vulnerable configuration surfaces.

## Test plan

- [x] `npm test` — all 2084 tests pass across 90 suites
- [x] Confirmed lockfile resolves axios to `1.18.1`
- [x] Verified remaining `npm audit` findings are dev-only transitive deps (babel, brace-expansion, fast-uri, js-yaml), not shipped in `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated the HTTP request library to address multiple known security vulnerabilities.

* **Bug Fixes**
  * Fixed sharing requests that could fail because of malformed or duplicated query strings.
  * Fixed asset-sharing updates that could trigger a runtime error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->