### PR TITLE
Support include=planName on List User Plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added support for the `include` query parameter on `users.listUserPlans` (`GET /2.0/users/{userId}/plans`). The only accepted value is `planName`.
+- Added support for the `include` query parameter on `users.listUserPlans` (`GET /2.0/users/{userId}/plans`), accepting either an array of `ListUserPlansInclusion` values or a comma-separated string. Arrays are joined into a single comma-separated value. The only currently accepted value is `ListUserPlansInclusion.PLAN_NAME` (`planName`).
 - Added an optional `planName` field to each plan in `ListUserPlansResponse`, populated with the owning organization's name when `include=planName` is requested.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [X.X.X] - Unreleased
 
+### Added
+
+- Added support for the `include` query parameter on `users.listUserPlans` (`GET /2.0/users/{userId}/plans`). The only accepted value is `planNames`.
+- Added an optional `planName` field to each plan in `ListUserPlansResponse`, populated with the owning organization's name when `include=planNames` is requested.
+
 ### Security
 
 - Bumped `axios` to `^1.18.0` to resolve six security advisories (GHSA-gcfj-64vw-6mp9, GHSA-jqh4-m9w3-8hp9, GHSA-hcpx-6fm6-wx23, GHSA-mwf2-3pr3-8698, GHSA-f4gw-2p7v-4548, GHSA-xj6q-8x83-jv6g), all patched in axios 1.18.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Added support for the `include` query parameter on `users.listUserPlans` (`GET /2.0/users/{userId}/plans`). The only accepted value is `planNames`.
-- Added an optional `planName` field to each plan in `ListUserPlansResponse`, populated with the owning organization's name when `include=planNames` is requested.
+- Added support for the `include` query parameter on `users.listUserPlans` (`GET /2.0/users/{userId}/plans`). The only accepted value is `planName`.
+- Added an optional `planName` field to each plan in `ListUserPlansResponse`, populated with the owning organization's name when `include=planName` is requested.
 
 ### Security
 

--- a/lib/users/index.ts
+++ b/lib/users/index.ts
@@ -109,7 +109,17 @@ export function create(options: CreateOptions): UsersApi & AlternateEmailsApi {
 
   const listUserPlans = (getOptions: ListUserPlansOptions, callback?: RequestCallback<ListUserPlansResponse>) => {
     const urlOptions = { url: buildListUserPlansUrl(getOptions) };
-    const requestOptions = { ...optionsToSend, ...urlOptions, ...getOptions };
+
+    // Transform include array to comma-separated string if needed
+    const processedOptions = { ...getOptions };
+    if (processedOptions.queryParameters?.include && Array.isArray(processedOptions.queryParameters.include)) {
+      processedOptions.queryParameters = {
+        ...processedOptions.queryParameters,
+        include: processedOptions.queryParameters.include.join(','),
+      };
+    }
+
+    const requestOptions = { ...optionsToSend, ...urlOptions, ...processedOptions };
     return requestor.get(requestOptions, callback);
   };
 

--- a/lib/users/types.ts
+++ b/lib/users/types.ts
@@ -1420,6 +1420,10 @@ export interface DowngradeUserOptions extends RequestOptions<undefined, Downgrad
 // List User Plans
 // ============================================================================
 
+export enum ListUserPlansInclusion {
+  PLAN_NAME = 'planName',
+}
+
 export interface ListUserPlansQueryParameters {
   /**
    * The lastKey token returned from the previous page of results.
@@ -1438,12 +1442,14 @@ export interface ListUserPlansQueryParameters {
    */
   displayContributorSeatType?: boolean;
   /**
-   * A comma-separated list of elements to include in the response. The only
-   * accepted value is `planName`, which populates `planName` on each returned
-   * plan with the name of its owning organization. An unrecognized value, or
-   * the same value more than once, returns a 400.
+   * The elements to include in the response, either as an array of
+   * {@link ListUserPlansInclusion} values or as an already comma-separated
+   * string. {@link ListUserPlansInclusion.PLAN_NAME} populates `planName` on
+   * each returned plan with the name of its owning organization. An
+   * unrecognized value, or the same value more than once, returns a 400.
+   * @see ListUserPlansInclusion
    */
-  include?: 'planName';
+  include?: string | ListUserPlansInclusion[];
 }
 
 export interface ListUserPlansOptions extends RequestOptions<ListUserPlansQueryParameters, undefined> {

--- a/lib/users/types.ts
+++ b/lib/users/types.ts
@@ -1437,6 +1437,13 @@ export interface ListUserPlansQueryParameters {
    * @defaultValue false
    */
   displayContributorSeatType?: boolean;
+  /**
+   * A comma-separated list of elements to include in the response. The only
+   * accepted value is `planNames`, which populates `planName` on each returned
+   * plan with the name of its owning organization. An unrecognized value
+   * returns a 400.
+   */
+  include?: 'planNames';
 }
 
 export interface ListUserPlansOptions extends RequestOptions<ListUserPlansQueryParameters, undefined> {
@@ -1459,6 +1466,16 @@ export interface ListUserPlansResponse {
      * Plan Id.
      */
     planId: number;
+    /**
+     * Name of the organization that owns the plan. Returned only when
+     * `include=planNames` is requested, and omitted for a plan whose owning
+     * organization has no name.
+     *
+     * @remarks
+     * Organization names are cached for roughly four hours downstream, so a
+     * recently renamed organization may briefly report its previous name.
+     */
+    planName?: string;
     /**
      * User's seat type.
      * @see SeatTypes

--- a/lib/users/types.ts
+++ b/lib/users/types.ts
@@ -1439,11 +1439,11 @@ export interface ListUserPlansQueryParameters {
   displayContributorSeatType?: boolean;
   /**
    * A comma-separated list of elements to include in the response. The only
-   * accepted value is `planNames`, which populates `planName` on each returned
-   * plan with the name of its owning organization. An unrecognized value
-   * returns a 400.
+   * accepted value is `planName`, which populates `planName` on each returned
+   * plan with the name of its owning organization. An unrecognized value, or
+   * the same value more than once, returns a 400.
    */
-  include?: 'planNames';
+  include?: 'planName';
 }
 
 export interface ListUserPlansOptions extends RequestOptions<ListUserPlansQueryParameters, undefined> {
@@ -1468,7 +1468,7 @@ export interface ListUserPlansResponse {
     planId: number;
     /**
      * Name of the organization that owns the plan. Returned only when
-     * `include=planNames` is requested, and omitted for a plan whose owning
+     * `include=planName` is requested, and omitted for a plan whose owning
      * organization has no name.
      *
      * @remarks

--- a/test/mock-api/users/common_test_constants.ts
+++ b/test/mock-api/users/common_test_constants.ts
@@ -52,8 +52,6 @@ export const ADD_PROFILE_IMAGE_REQUEST_BODY = Buffer.from('fake-image-data');
 export const TEST_LAST_KEY = '12345678901234569';
 export const TEST_MAX_ITEMS = 100;
 export const TEST_INCLUDE_ALL = false;
-export const TEST_INCLUDE_PLAN_NAME = 'planName' as const;
-export const TEST_PLAN_NAME = 'Acme Corporation';
 
 // Common Query Parameters for remove_user
 export const TEST_TRANSFER_TO_USER_ID = 9876543210987654;

--- a/test/mock-api/users/common_test_constants.ts
+++ b/test/mock-api/users/common_test_constants.ts
@@ -52,6 +52,8 @@ export const ADD_PROFILE_IMAGE_REQUEST_BODY = Buffer.from('fake-image-data');
 export const TEST_LAST_KEY = '12345678901234569';
 export const TEST_MAX_ITEMS = 100;
 export const TEST_INCLUDE_ALL = false;
+export const TEST_INCLUDE_PLAN_NAMES = 'planNames' as const;
+export const TEST_PLAN_NAME = 'Acme Corporation';
 
 // Common Query Parameters for remove_user
 export const TEST_TRANSFER_TO_USER_ID = 9876543210987654;

--- a/test/mock-api/users/common_test_constants.ts
+++ b/test/mock-api/users/common_test_constants.ts
@@ -52,7 +52,7 @@ export const ADD_PROFILE_IMAGE_REQUEST_BODY = Buffer.from('fake-image-data');
 export const TEST_LAST_KEY = '12345678901234569';
 export const TEST_MAX_ITEMS = 100;
 export const TEST_INCLUDE_ALL = false;
-export const TEST_INCLUDE_PLAN_NAMES = 'planNames' as const;
+export const TEST_INCLUDE_PLAN_NAME = 'planName' as const;
 export const TEST_PLAN_NAME = 'Acme Corporation';
 
 // Common Query Parameters for remove_user

--- a/test/mock-api/users/list_user_plans.spec.ts
+++ b/test/mock-api/users/list_user_plans.spec.ts
@@ -12,11 +12,12 @@ import {
     TEST_PROVISIONAL_EXPIRATION_DATE,
     TEST_LAST_KEY,
     TEST_MAX_ITEMS,
-    TEST_CONTRIBUTOR_PLAN_ID,
-    TEST_INCLUDE_PLAN_NAME,
-    TEST_PLAN_NAME
+    TEST_CONTRIBUTOR_PLAN_ID
 } from './common_test_constants';
-import { SeatTypes } from '@smartsheet/users/types';
+import { ListUserPlansInclusion, SeatTypes } from '@smartsheet/users/types';
+
+const TEST_INCLUDE_PLAN_NAME = [ListUserPlansInclusion.PLAN_NAME];
+const TEST_PLAN_NAME = 'Acme Corporation';
 
 describe('Users - listUserPlans endpoint tests', () => {
     const client = createClient();
@@ -46,8 +47,30 @@ describe('Users - listUserPlans endpoint tests', () => {
             lastKey: TEST_LAST_KEY,
             maxItems: TEST_MAX_ITEMS.toString(),
             displayContributorSeatType: 'true',
-            include: TEST_INCLUDE_PLAN_NAME
+            // The inclusion array is joined into a single comma-separated
+            // value rather than repeated as include[]=.
+            include: ListUserPlansInclusion.PLAN_NAME
         });
+    });
+
+    it('listUserPlans accepts include as a comma-separated string', async () => {
+        const requestId = crypto.randomUUID();
+        const options = {
+            userId: TEST_USER_ID,
+            queryParameters: {
+                include: ListUserPlansInclusion.PLAN_NAME as string
+            },
+            customProperties: {
+                'x-request-id': requestId,
+                'x-test-name': '/users/list-user-plans/all-response-body-properties'
+            }
+        };
+        await client.users.listUserPlans(options);
+        const matchedRequest = await findWireMockRequest(requestId);
+        const parsedUrl = new URL(matchedRequest.absoluteUrl);
+
+        const queryParamsObject = Object.fromEntries(parsedUrl.searchParams);
+        expect(queryParamsObject).toEqual({ include: ListUserPlansInclusion.PLAN_NAME });
     });
 
     it('listUserPlans all response body properties', async () => {

--- a/test/mock-api/users/list_user_plans.spec.ts
+++ b/test/mock-api/users/list_user_plans.spec.ts
@@ -13,7 +13,7 @@ import {
     TEST_LAST_KEY,
     TEST_MAX_ITEMS,
     TEST_CONTRIBUTOR_PLAN_ID,
-    TEST_INCLUDE_PLAN_NAMES,
+    TEST_INCLUDE_PLAN_NAME,
     TEST_PLAN_NAME
 } from './common_test_constants';
 import { SeatTypes } from '@smartsheet/users/types';
@@ -29,7 +29,7 @@ describe('Users - listUserPlans endpoint tests', () => {
                 lastKey: TEST_LAST_KEY,
                 maxItems: TEST_MAX_ITEMS,
                 displayContributorSeatType: true,
-                include: TEST_INCLUDE_PLAN_NAMES
+                include: TEST_INCLUDE_PLAN_NAME
             },
             customProperties: {
                 'x-request-id': requestId,
@@ -46,7 +46,7 @@ describe('Users - listUserPlans endpoint tests', () => {
             lastKey: TEST_LAST_KEY,
             maxItems: TEST_MAX_ITEMS.toString(),
             displayContributorSeatType: 'true',
-            include: TEST_INCLUDE_PLAN_NAMES
+            include: TEST_INCLUDE_PLAN_NAME
         });
     });
 
@@ -57,7 +57,7 @@ describe('Users - listUserPlans endpoint tests', () => {
             queryParameters: {
                 lastKey: TEST_LAST_KEY,
                 maxItems: TEST_MAX_ITEMS,
-                include: TEST_INCLUDE_PLAN_NAMES
+                include: TEST_INCLUDE_PLAN_NAME
             },
             customProperties: {
                 'x-request-id': requestId,

--- a/test/mock-api/users/list_user_plans.spec.ts
+++ b/test/mock-api/users/list_user_plans.spec.ts
@@ -12,7 +12,9 @@ import {
     TEST_PROVISIONAL_EXPIRATION_DATE,
     TEST_LAST_KEY,
     TEST_MAX_ITEMS,
-    TEST_CONTRIBUTOR_PLAN_ID
+    TEST_CONTRIBUTOR_PLAN_ID,
+    TEST_INCLUDE_PLAN_NAMES,
+    TEST_PLAN_NAME
 } from './common_test_constants';
 import { SeatTypes } from '@smartsheet/users/types';
 
@@ -26,7 +28,8 @@ describe('Users - listUserPlans endpoint tests', () => {
             queryParameters: {
                 lastKey: TEST_LAST_KEY,
                 maxItems: TEST_MAX_ITEMS,
-                displayContributorSeatType: true
+                displayContributorSeatType: true,
+                include: TEST_INCLUDE_PLAN_NAMES
             },
             customProperties: {
                 'x-request-id': requestId,
@@ -42,7 +45,8 @@ describe('Users - listUserPlans endpoint tests', () => {
         expect(queryParamsObject).toEqual({
             lastKey: TEST_LAST_KEY,
             maxItems: TEST_MAX_ITEMS.toString(),
-            displayContributorSeatType: 'true'
+            displayContributorSeatType: 'true',
+            include: TEST_INCLUDE_PLAN_NAMES
         });
     });
 
@@ -52,7 +56,8 @@ describe('Users - listUserPlans endpoint tests', () => {
             userId: TEST_USER_ID,
             queryParameters: {
                 lastKey: TEST_LAST_KEY,
-                maxItems: TEST_MAX_ITEMS
+                maxItems: TEST_MAX_ITEMS,
+                include: TEST_INCLUDE_PLAN_NAMES
             },
             customProperties: {
                 'x-request-id': requestId,
@@ -66,12 +71,15 @@ describe('Users - listUserPlans endpoint tests', () => {
             data: [
                 {
                     planId: TEST_PLAN_ID,
+                    planName: TEST_PLAN_NAME,
                     seatType: SeatTypes.MEMBER,
                     seatTypeLastChangedAt: TEST_SEAT_TYPE_LAST_CHANGED_AT,
                     provisionalExpirationDate: TEST_PROVISIONAL_EXPIRATION_DATE,
                     isInternal: false
                 },
                 {
+                    // Omits the optional planName, as a plan whose owning
+                    // organization has no name does.
                     planId: TEST_CONTRIBUTOR_PLAN_ID,
                     seatType: SeatTypes.CONTRIBUTOR,
                     seatTypeLastChangedAt: TEST_SEAT_TYPE_LAST_CHANGED_AT,
@@ -80,6 +88,7 @@ describe('Users - listUserPlans endpoint tests', () => {
                 }
             ]
         });
+        expect(response.data[1].planName).toBeUndefined();
     });
 
     it('listUserPlans required response body properties', async () => {
@@ -92,7 +101,7 @@ describe('Users - listUserPlans endpoint tests', () => {
             }
         };
         const response = await client.users.listUserPlans(options);
-        
+
         expect(response).toEqual({
             data: [
                 {
@@ -102,6 +111,7 @@ describe('Users - listUserPlans endpoint tests', () => {
                 }
             ]
         });
+        expect(response.data[0].planName).toBeUndefined();
     });
 
     it('listUserPlans error 500 response', async () => {


### PR DESCRIPTION
## Summary

`GET /2.0/users/{userId}/plans` gained an optional `include` query parameter whose only accepted value is `planName`, matching the response field it controls. When requested, each returned plan carries the name of the organization that owns it. This adds SDK type support for both halves of that change.

- `ListUserPlansQueryParameters` gains `include?: 'planName'`.
- Each item in `ListUserPlansResponse.data[]` gains `planName?: string`.

Omitting `include` is byte-identical to today's behavior: the parameter is optional, nothing is added to the query string, and the response type only gains an optional field. This is purely additive and backward compatible.

## Design note: `include` is a string union, not an array

`include` is typed as the string literal union `'planName'` rather than `'planName'[]`. This is deliberate. The published contract is a single comma-separated parameter (`?include=planName`). An array type would serialize as `include[]=planName` under axios's default `paramsSerializer`, which this repo does not override — the wrong wire format. Typing it as a string keeps serialization correct with no per-call handling, since axios passes the value through verbatim.

`planName` is optional because it is absent in two distinct cases: when the enrichment is not requested, and when the owning organization has no name. Both surface as `undefined`. The HTTP layer passes the parsed JSON body through untouched, so no deserialization mapping was required.

A TSDoc `@remarks` note records that organization names are cached for roughly four hours downstream, so a recently renamed organization may briefly report its previous name. This is expected behavior rather than an SDK issue, and callers who cache or display the value should know about it.

## Files changed

- `lib/users/types.ts` — `include` on the query parameters, `planName` on the response plan item, both with TSDoc.
- `test/mock-api/users/common_test_constants.ts` — adds `TEST_INCLUDE_PLAN_NAME` and `TEST_PLAN_NAME`.
- `test/mock-api/users/list_user_plans.spec.ts` — asserts `include` is sent in the request params, that `planName` is populated on an enriched plan, and that it is `undefined` both for a plan whose organization has no name and in the required-properties case.
- `CHANGELOG.md` — two entries under Unreleased / Added.

## Testing

Mock API tests depend on `planName` being present in the List User Plans all-properties mapping in `smartsheet/smartsheet-sdk-tests`. That mapping change has merged, so these tests run green against the current `mainline` of that repo.

Full suite against the mock API: **2084 passed / 2084 total across 90 suites, 0 skipped, 0 failed.** `npm run lint` reports 0 errors, `npm run format` passes, and `tsc --noEmit` and `npm run build` both succeed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for requesting plan names when listing user plans.
  * Responses can now include an optional plan name for each plan.
  * Plan inclusion options support both comma-separated strings and arrays.

* **Bug Fixes**
  * Fixed request formatting for plan inclusion parameters.
  * Documented fixes for sharing request query duplication and missing PATCH support.
  * Updated security protections for HTTP and development dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
