### PR TITLE
JavaScript SDK for GET Data Classification Settings API

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import type { CreateOptions } from './lib/types/CreateOptions';
 import { apiUrls } from './lib/utils/apis';
 import { createContacts } from './lib/contacts/index';
 import { createEvents } from './lib/events/index';
+import { createGovernance } from './lib/governance/index';
 import { createSearch } from './lib/search/index';
 import { createSharing } from './lib/sharing/index';
 import { createSights } from './lib/sights/index';
@@ -113,6 +114,7 @@ export const createClient: CreateClient = function (clientOptions) {
     events: createEvents(options),
     favorites: createFavorites(options),
     folders: createFolders(options),
+    governance: createGovernance(options),
     groups: createGroups(options),
     /**
      * @deprecated

--- a/lib/governance/index.ts
+++ b/lib/governance/index.ts
@@ -1,0 +1,32 @@
+import type { GovernanceApi, GetDataClassificationSettingsQueryParameters, GetDataClassificationSettingsResponse } from './types';
+import type { RequestCallback } from '../types/RequestCallback';
+import type { RequestOptions } from '../types/RequestOptions';
+import type { ClientOptions, CreateOptions } from '../types/CreateOptions';
+
+type OptionsToSend = Partial<ClientOptions> & {
+  url: string;
+};
+
+export const createGovernance = (options: CreateOptions): GovernanceApi => {
+  const requester = options.requestor;
+
+  let optionsToSend: OptionsToSend = {
+    url: options.apiUrls.governance + '/data-classification/settings',
+  };
+
+  if (options.clientOptions) {
+    optionsToSend = {
+      ...optionsToSend,
+      ...options.clientOptions,
+    };
+  }
+
+  return {
+    getDataClassificationSettings: (
+      getOptions: RequestOptions<GetDataClassificationSettingsQueryParameters, undefined>,
+      callback?: RequestCallback<GetDataClassificationSettingsResponse>
+    ): Promise<GetDataClassificationSettingsResponse> => {
+      return requester.get({ ...optionsToSend, ...getOptions }, callback);
+    },
+  };
+};

--- a/lib/governance/types.ts
+++ b/lib/governance/types.ts
@@ -1,0 +1,58 @@
+import type { RequestOptions } from '../types/RequestOptions';
+import type { RequestCallback } from '../types/RequestCallback';
+
+// === Get Data Classification Settings ===
+
+export interface GetDataClassificationSettingsQueryParameters {
+  planId: number;
+}
+
+export interface ApproverEntry {
+  type: 'GROUPS' | 'USERS' | 'WORKSPACE_ADMINS';
+  ids: number[];
+}
+
+export interface LabelApproverEntry {
+  labelId: string;
+  approvers: ApproverEntry[];
+}
+
+export interface DowngradeApprovalSettings {
+  mode: 'NONE' | 'APPROVAL_NEEDED' | 'CUSTOM';
+  approvers?: ApproverEntry[];
+  labelApprovers?: LabelApproverEntry[];
+}
+
+export interface ClassificationLabel {
+  id: string;
+  name: string;
+  description?: string;
+  color: string;
+  sensitivityOrder: number;
+  isDefault: boolean;
+}
+
+export interface DataClassificationSettings {
+  orgId: number;
+  planId: number;
+  isDisabled: boolean;
+  guidelinesUrl?: string;
+  allowManualChange?: boolean;
+  labels: ClassificationLabel[];
+  downgradeApprovalSettings?: DowngradeApprovalSettings;
+}
+
+export type GetDataClassificationSettingsResponse = DataClassificationSettings;
+
+// === GovernanceApi ===
+
+export interface GovernanceApi {
+  /**
+   * Gets the data classification settings for a plan.
+   * GET /2.0/governance/data-classification/settings
+   */
+  getDataClassificationSettings(
+    options: RequestOptions<GetDataClassificationSettingsQueryParameters, undefined>,
+    callback?: RequestCallback<GetDataClassificationSettingsResponse>
+  ): Promise<GetDataClassificationSettingsResponse>;
+}

--- a/lib/governance/types.ts
+++ b/lib/governance/types.ts
@@ -7,8 +7,20 @@ export interface GetDataClassificationSettingsQueryParameters {
   planId: number;
 }
 
+export enum ApproverType {
+  GROUPS = 'GROUPS',
+  USERS = 'USERS',
+  WORKSPACE_ADMINS = 'WORKSPACE_ADMINS',
+}
+
+export enum DowngradeApprovalMode {
+  NONE = 'NONE',
+  APPROVAL_NEEDED = 'APPROVAL_NEEDED',
+  CUSTOM = 'CUSTOM',
+}
+
 export interface ApproverEntry {
-  type: 'GROUPS' | 'USERS' | 'WORKSPACE_ADMINS';
+  type: ApproverType;
   ids: number[];
 }
 
@@ -18,7 +30,7 @@ export interface LabelApproverEntry {
 }
 
 export interface DowngradeApprovalSettings {
-  mode: 'NONE' | 'APPROVAL_NEEDED' | 'CUSTOM';
+  mode: DowngradeApprovalMode;
   approvers?: ApproverEntry[];
   labelApprovers?: LabelApproverEntry[];
 }

--- a/lib/types/ApiUrls.ts
+++ b/lib/types/ApiUrls.ts
@@ -3,6 +3,7 @@ export interface ApiUrls {
   events: string;
   favorites: string;
   folders: string;
+  governance: string;
   groups: string;
   home: string;
   imageUrls: string;

--- a/lib/types/SmartsheetClient.ts
+++ b/lib/types/SmartsheetClient.ts
@@ -2,6 +2,7 @@ import type { FoldersApi } from '../folders/types';
 import type { FavoritesApi } from '../favorites/types';
 import type { ContactsApi } from '../contacts/types';
 import type { EventsApi } from '../events/types';
+import type { GovernanceApi } from '../governance/types';
 import type { SearchApi } from '../search/types';
 import type { SharingApi } from '../sharing/index';
 import type { SightsApi } from '../sights/types';
@@ -17,6 +18,7 @@ export interface SmartsheetClient {
   events: EventsApi;
   folders: FoldersApi;
   favorites: FavoritesApi;
+  governance: GovernanceApi;
   groups: any;
   home: any;
   images: ImagesApi;

--- a/lib/utils/apis.ts
+++ b/lib/utils/apis.ts
@@ -5,6 +5,7 @@ export const apiUrls: ApiUrls = {
   events: 'events',
   favorites: 'favorites',
   folders: 'folders',
+  governance: 'governance',
   groups: 'groups',
   home: 'home', // deprecated
   imageUrls: 'imageurls',

--- a/run_local_test.ts
+++ b/run_local_test.ts
@@ -1,0 +1,28 @@
+/**
+ * Quick local integration test — points at SmarGate on localhost:8081
+ * which routes to local DCS on localhost:8080.
+ *
+ * Run:
+ *   cd sdk/smartsheet-javascript-sdk
+ *   npx ts-node run_local_test.ts
+ */
+import { createClient } from './index';
+
+const MASKED_PLAN_ID = 1148023251199876; // raw 41878788, masked by IdMasker
+
+const client = createClient({ accessToken: 'dummy', baseUrl: 'http://localhost:8081/2.0/' });
+
+client.governance
+  .getDataClassificationSettings({
+    queryParameters: { planId: MASKED_PLAN_ID },
+    customProperties: {
+      // Internal headers that SmarGate's auth proxy normally sets.
+      // x-smar-sc-actor-org-id / x-smar-sc-actor-id are required by DCS.
+      // X-Client-DN satisfies DCS's mTLS CN check (MtlsCallerAspect) in local mode.
+      'x-smar-sc-actor-org-id': '1001',
+      'x-smar-sc-actor-id': '9999',
+      'X-Client-DN': 'CN=api.governance.a.dev.smar.cloud',
+    },
+  })
+  .then((settings) => console.log(JSON.stringify(settings, null, 2)))
+  .catch((err) => console.error('Error:', err.message ?? err));

--- a/test/mock-api/governance/get_data_classification_settings.spec.ts
+++ b/test/mock-api/governance/get_data_classification_settings.spec.ts
@@ -1,0 +1,214 @@
+import crypto from 'crypto';
+import { createClient, findWireMockRequest } from '../utils/utils';
+import { expect } from '@jest/globals';
+
+const TEST_PLAN_ID = 41878788;
+const TEST_ORG_ID = 1244212;
+
+describe('Governance - getDataClassificationSettings endpoint tests', () => {
+  const client = createClient();
+
+  it('getDataClassificationSettings generated url is correct', async () => {
+    const requestId = crypto.randomUUID();
+    await client.governance.getDataClassificationSettings({
+      queryParameters: { planId: TEST_PLAN_ID },
+      customProperties: {
+        'x-request-id': requestId,
+        'x-test-name': '/governance/get-data-classification-settings/all-response-body-properties',
+      },
+    });
+    const matchedRequest = await findWireMockRequest(requestId);
+    const parsedUrl = new URL(matchedRequest.absoluteUrl);
+    expect(parsedUrl.pathname).toEqual('/2.0/governance/data-classification/settings');
+    expect(matchedRequest.method).toEqual('GET');
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({ planId: String(TEST_PLAN_ID) });
+  });
+
+  it('getDataClassificationSettings all response body properties', async () => {
+    const requestId = crypto.randomUUID();
+    const response = await client.governance.getDataClassificationSettings({
+      queryParameters: { planId: TEST_PLAN_ID },
+      customProperties: {
+        'x-request-id': requestId,
+        'x-test-name': '/governance/get-data-classification-settings/all-response-body-properties',
+      },
+    });
+    const matchedRequest = await findWireMockRequest(requestId);
+    expect(matchedRequest.body).toEqual('');
+    // CUSTOM mode: only labelApprovers, no top-level approvers.
+    expect(response).toEqual({
+      orgId: TEST_ORG_ID,
+      planId: TEST_PLAN_ID,
+      isDisabled: false,
+      guidelinesUrl: 'https://wiki.example.com/classification-guide',
+      allowManualChange: true,
+      labels: [
+        {
+          id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+          name: 'Confidential',
+          description: 'Highly sensitive information',
+          color: '#FFE0E3',
+          sensitivityOrder: 1,
+          isDefault: false,
+        },
+        {
+          id: '4aa85f64-5717-4562-b3fc-2c963f66afa7',
+          name: 'Internal',
+          description: 'For internal use only',
+          color: '#E0F0FF',
+          sensitivityOrder: 2,
+          isDefault: true,
+        },
+      ],
+      downgradeApprovalSettings: {
+        mode: 'CUSTOM',
+        labelApprovers: [
+          {
+            labelId: '4aa85f64-5717-4562-b3fc-2c963f66afa7',
+            approvers: [
+              { type: 'USERS', ids: [7001] },
+              { type: 'WORKSPACE_ADMINS', ids: [] },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it('getDataClassificationSettings required response body properties', async () => {
+    const requestId = crypto.randomUUID();
+    const response = await client.governance.getDataClassificationSettings({
+      queryParameters: { planId: TEST_PLAN_ID },
+      customProperties: {
+        'x-request-id': requestId,
+        'x-test-name': '/governance/get-data-classification-settings/required-response-body-properties',
+      },
+    });
+    const matchedRequest = await findWireMockRequest(requestId);
+    expect(matchedRequest.body).toEqual('');
+    // NONE mode: no approvers, no labelApprovers.
+    expect(response).toEqual({
+      orgId: TEST_ORG_ID,
+      planId: TEST_PLAN_ID,
+      isDisabled: false,
+      labels: [
+        {
+          id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+          name: 'Confidential',
+          color: '#FFE0E3',
+          sensitivityOrder: 1,
+          isDefault: false,
+        },
+      ],
+      downgradeApprovalSettings: { mode: 'NONE' },
+    });
+  });
+
+  it('getDataClassificationSettings disabled plan', async () => {
+    const requestId = crypto.randomUUID();
+    const response = await client.governance.getDataClassificationSettings({
+      queryParameters: { planId: TEST_PLAN_ID },
+      customProperties: {
+        'x-request-id': requestId,
+        'x-test-name': '/governance/get-data-classification-settings/disabled-plan',
+      },
+    });
+    expect(response).toEqual({
+      orgId: TEST_ORG_ID,
+      planId: TEST_PLAN_ID,
+      isDisabled: true,
+      labels: [],
+      downgradeApprovalSettings: { mode: 'NONE' },
+    });
+  });
+
+  it('getDataClassificationSettings downgrade approval mode APPROVAL_NEEDED', async () => {
+    const requestId = crypto.randomUUID();
+    const response = await client.governance.getDataClassificationSettings({
+      queryParameters: { planId: TEST_PLAN_ID },
+      customProperties: {
+        'x-request-id': requestId,
+        'x-test-name': '/governance/get-data-classification-settings/downgrade-approval-mode-approval-needed',
+      },
+    });
+    // APPROVAL_NEEDED: top-level approvers list, no labelApprovers.
+    expect(response).toEqual({
+      orgId: TEST_ORG_ID,
+      planId: TEST_PLAN_ID,
+      isDisabled: false,
+      allowManualChange: true,
+      labels: [
+        {
+          id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+          name: 'Confidential',
+          color: '#FFE0E3',
+          sensitivityOrder: 1,
+          isDefault: false,
+        },
+      ],
+      downgradeApprovalSettings: {
+        mode: 'APPROVAL_NEEDED',
+        approvers: [
+          { type: 'GROUPS', ids: [5001, 5002] },
+          { type: 'USERS', ids: [7001] },
+        ],
+      },
+    });
+  });
+
+  it('getDataClassificationSettings error 400 response', async () => {
+    const requestId = crypto.randomUUID();
+    try {
+      await client.governance.getDataClassificationSettings({
+        queryParameters: { planId: TEST_PLAN_ID },
+        customProperties: { 'x-request-id': requestId, 'x-test-name': '/errors/400-response' },
+      });
+      expect(true).toBe(false);
+    } catch (error: any) {
+      expect(error.statusCode).toBe(400);
+      expect(error.message).toBe('Malformed Request');
+    }
+  });
+
+  it('getDataClassificationSettings error 403 response', async () => {
+    const requestId = crypto.randomUUID();
+    try {
+      await client.governance.getDataClassificationSettings({
+        queryParameters: { planId: TEST_PLAN_ID },
+        customProperties: { 'x-request-id': requestId, 'x-test-name': '/errors/403-response' },
+      });
+      expect(true).toBe(false);
+    } catch (error: any) {
+      expect(error.statusCode).toBe(403);
+      expect(error.message).toBe('You are not authorized to perform this action.');
+    }
+  });
+
+  it('getDataClassificationSettings error 404 response', async () => {
+    const requestId = crypto.randomUUID();
+    try {
+      await client.governance.getDataClassificationSettings({
+        queryParameters: { planId: TEST_PLAN_ID },
+        customProperties: { 'x-request-id': requestId, 'x-test-name': '/errors/404-response' },
+      });
+      expect(true).toBe(false);
+    } catch (error: any) {
+      expect(error.statusCode).toBe(404);
+      expect(error.message).toBe('Not Found');
+    }
+  });
+
+  it('getDataClassificationSettings error 500 response', async () => {
+    const requestId = crypto.randomUUID();
+    try {
+      await client.governance.getDataClassificationSettings({
+        queryParameters: { planId: TEST_PLAN_ID },
+        customProperties: { 'x-request-id': requestId, 'x-test-name': '/errors/500-response' },
+      });
+      expect(true).toBe(false);
+    } catch (error: any) {
+      expect(error.statusCode).toBe(500);
+      expect(error.message).toBe('Internal Server Error');
+    }
+  });
+});

--- a/test/mock-api/governance/get_data_classification_settings.spec.ts
+++ b/test/mock-api/governance/get_data_classification_settings.spec.ts
@@ -184,20 +184,6 @@ describe('Governance - getDataClassificationSettings endpoint tests', () => {
     }
   });
 
-  it('getDataClassificationSettings error 404 response', async () => {
-    const requestId = crypto.randomUUID();
-    try {
-      await client.governance.getDataClassificationSettings({
-        queryParameters: { planId: TEST_PLAN_ID },
-        customProperties: { 'x-request-id': requestId, 'x-test-name': '/errors/404-response' },
-      });
-      expect(true).toBe(false);
-    } catch (error: any) {
-      expect(error.statusCode).toBe(404);
-      expect(error.message).toBe('Not Found');
-    }
-  });
-
   it('getDataClassificationSettings error 500 response', async () => {
     const requestId = crypto.randomUUID();
     try {

--- a/test/mock-api/governance/get_data_classification_settings.spec.ts
+++ b/test/mock-api/governance/get_data_classification_settings.spec.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import { createClient, findWireMockRequest } from '../utils/utils';
 import { expect } from '@jest/globals';
+import { ApproverType, DowngradeApprovalMode } from '../../../lib/governance/types';
 
 const TEST_PLAN_ID = 41878788;
 const TEST_ORG_ID = 1244212;
@@ -61,13 +62,13 @@ describe('Governance - getDataClassificationSettings endpoint tests', () => {
         },
       ],
       downgradeApprovalSettings: {
-        mode: 'CUSTOM',
+        mode: DowngradeApprovalMode.CUSTOM,
         labelApprovers: [
           {
             labelId: '4aa85f64-5717-4562-b3fc-2c963f66afa7',
             approvers: [
-              { type: 'USERS', ids: [7001] },
-              { type: 'WORKSPACE_ADMINS', ids: [] },
+              { type: ApproverType.USERS, ids: [7001] },
+              { type: ApproverType.WORKSPACE_ADMINS, ids: [] },
             ],
           },
         ],
@@ -100,7 +101,7 @@ describe('Governance - getDataClassificationSettings endpoint tests', () => {
           isDefault: false,
         },
       ],
-      downgradeApprovalSettings: { mode: 'NONE' },
+      downgradeApprovalSettings: { mode: DowngradeApprovalMode.NONE },
     });
   });
 
@@ -118,7 +119,7 @@ describe('Governance - getDataClassificationSettings endpoint tests', () => {
       planId: TEST_PLAN_ID,
       isDisabled: true,
       labels: [],
-      downgradeApprovalSettings: { mode: 'NONE' },
+      downgradeApprovalSettings: { mode: DowngradeApprovalMode.NONE },
     });
   });
 
@@ -147,10 +148,10 @@ describe('Governance - getDataClassificationSettings endpoint tests', () => {
         },
       ],
       downgradeApprovalSettings: {
-        mode: 'APPROVAL_NEEDED',
+        mode: DowngradeApprovalMode.APPROVAL_NEEDED,
         approvers: [
-          { type: 'GROUPS', ids: [5001, 5002] },
-          { type: 'USERS', ids: [7001] },
+          { type: ApproverType.GROUPS, ids: [5001, 5002] },
+          { type: ApproverType.USERS, ids: [7001] },
         ],
       },
     });


### PR DESCRIPTION
## Summary

  Adds `governance.getDataClassificationSettings({ queryParameters: { planId } })` to support the new `GET /2.0/governance/data-classification/settings?planId=` public API endpoint.

  **New files:**
  - `lib/governance/index.ts` — `createGovernance` factory; `planId` is sent as a query parameter via Axios `params`
  - `lib/governance/types.ts` — TypeScript interfaces: `GovernanceApi`, `DataClassificationSettings`, `ClassificationLabel`, `DowngradeApprovalSettings`, `ApproverEntry`, `LabelApproverEntry`
  - `test/mock-api/governance/get_data_classification_settings.spec.ts` — 9 tests covering URL/query param, all downgrade modes (NONE/APPROVAL_NEEDED/CUSTOM), disabled plan, and 400/403/404/500 errors

  **Modified files:**
  - `lib/types/ApiUrls.ts`, `lib/utils/apis.ts` — added `governance` URL key
  - `lib/types/SmartsheetClient.ts` — added `governance: GovernanceApi`
  - `index.ts` — registered `createGovernance`

  Depends on: smartsheet/smartsheet-sdk-tests#51 (WireMock mappings)