### PR TITLE
FIND-3495: Surface 5 new search types in JavaScript SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [X.X.X] - Unreleased
 
+### Added
+
+- `SearchResultType` enum: added 9 new values for the search-service API path — `GridRow` (`GRID_ROW`), `Attachment` (`ATTACHMENT`), `SheetV2` (`SHEET`), `WorkspaceV2` (`WORKSPACE`), `Form` (`FORM`), `CollectionTitle` (`COLLECTION_TITLE`), `PortfolioTitle` (`PORTFOLIO_TITLE`), `ProjectTitle` (`PROJECT_TITLE`), `ScenarioPlanTitle` (`SCENARIO_PLAN_TITLE`).
+- New optional fields on `SearchResult`: `workspaceId`, `containerId`, `modifyDateTime`, `primaryColumnCellText` (GRID_ROW only), `attachmentSource` (ATTACHMENT only), `attachmentDescription` (ATTACHMENT only), `isTemplate` (SHEET only).
+- `SearchResponse` now includes `searchResults` (new API field), `workspaces`, and `personalWorkspaceId`. The legacy `results` field is kept for backward compatibility.
+
 ## [5.3.0] - 2026-08-12
 
 ### Added

--- a/lib/search/types.ts
+++ b/lib/search/types.ts
@@ -8,6 +8,7 @@ export enum ParentResultType {
 }
 
 export enum SearchResultType {
+  // Legacy lowercase values (app-core path)
   Row = 'row',
   Dashboard = 'dashboard',
   Discussion = 'discussion',
@@ -17,6 +18,16 @@ export enum SearchResultType {
   SummaryField = 'summaryField',
   Template = 'template',
   Workspace = 'workspace',
+  // New UPPER_SNAKE_CASE values (search-service path)
+  GridRow = 'GRID_ROW',
+  Attachment = 'ATTACHMENT',
+  SheetV2 = 'SHEET',
+  WorkspaceV2 = 'WORKSPACE',
+  Form = 'FORM',
+  CollectionTitle = 'COLLECTION_TITLE',
+  PortfolioTitle = 'PORTFOLIO_TITLE',
+  ProjectTitle = 'PROJECT_TITLE',
+  ScenarioPlanTitle = 'SCENARIO_PLAN_TITLE',
 }
 
 export interface SearchResult {
@@ -38,11 +49,30 @@ export interface SearchResult {
   parentObjectName: string;
   // search result parent object type.
   parentObjectType: ParentResultType;
+  // ID of the workspace containing this result.
+  workspaceId?: string;
+  // ID of the direct container (sheet or folder) for this result.
+  containerId?: string;
+  // last-modified timestamp in milliseconds since the Unix epoch (UTC).
+  modifyDateTime?: number;
+  // primary-column cell text. Only populated for GRID_ROW results.
+  primaryColumnCellText?: string;
+  // object type the attachment belongs to (e.g., GRIDROW, DISCUSSION). Only populated for ATTACHMENT results.
+  attachmentSource?: string;
+  // user-provided attachment description. Only populated for ATTACHMENT results.
+  attachmentDescription?: string;
+  // true if this sheet result is a template. Only populated for SHEET results.
+  isTemplate?: boolean;
 }
 
 export interface SearchResponse {
   totalCount: number;
-  results: SearchResult[];
+  // Unified search-service response field (new API path).
+  searchResults?: SearchResult[];
+  // Legacy field name (app-core path). Use searchResults when available.
+  results?: SearchResult[];
+  workspaces?: object[];
+  personalWorkspaceId?: string | null;
 }
 
 export interface SearchQueryParameters {


### PR DESCRIPTION
Description:

  Updates lib/search/types.ts to expose the 5 new search result types now returned by the Smartsheet search-service API: FORM, COLLECTION_TITLE, PORTFOLIO_TITLE, PROJECT_TITLE,
  SCENARIO_PLAN_TITLE.

  Changes:

  - SearchResultType enum — added 9 new values for the search-service API path: GridRow (GRID_ROW), Attachment (ATTACHMENT), SheetV2 (SHEET), WorkspaceV2 (WORKSPACE), Form
    (FORM), CollectionTitle (COLLECTION_TITLE), PortfolioTitle (PORTFOLIO_TITLE), ProjectTitle (PROJECT_TITLE), ScenarioPlanTitle (SCENARIO_PLAN_TITLE). Legacy lowercase values
    are kept for backward compatibility.
  - SearchResult interface — added 7 new optional fields: workspaceId, containerId, modifyDateTime, primaryColumnCellText (GRID_ROW only), attachmentSource (ATTACHMENT only),
    attachmentDescription (ATTACHMENT only), isTemplate (SHEET only).
  - SearchResponse interface — added searchResults (new API field name), workspaces, and personalWorkspaceId. The existing results field is kept as optional for backward
    compatibility.
  - CHANGELOG.md — entry under [X.X.X] - Unreleased.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional search result types, including grids, attachments, sheets, workspaces, forms, collections, portfolios, projects, and scenario plans.
  * Added metadata for workspaces, containers, attachments, templates, rows, and modification details.
  * Added enhanced search response fields for search results, workspaces, and personal workspace information.
  * Preserved compatibility with existing search result responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->